### PR TITLE
Optimization of TRestRawSignal

### DIFF
--- a/inc/TRestRawSignalEvent.h
+++ b/inc/TRestRawSignalEvent.h
@@ -61,7 +61,7 @@ class TRestRawSignalEvent : public TRestEvent {
     }
 
     // Setters
-    void AddSignal(TRestRawSignal s);
+    void AddSignal(TRestRawSignal &s);
 
     void RemoveSignalWithId(Int_t sId);
 

--- a/src/TRestRawSignal.cxx
+++ b/src/TRestRawSignal.cxx
@@ -77,12 +77,11 @@ TRestRawSignal::TRestRawSignal() {
 /// \brief Default constructor initializing fSignalData with a number of points
 /// equal to nBins.
 ///
-TRestRawSignal::TRestRawSignal(Int_t nBins) {
-    fGraph = NULL;
+TRestRawSignal::TRestRawSignal(Int_t nBins) : fSignalData(nBins) {
+    fGraph = nullptr;
 
     Initialize();
 
-    for (int n = 0; n < nBins; n++) fSignalData.push_back(0);
 }
 
 ///////////////////////////////////////////////
@@ -94,7 +93,8 @@ TRestRawSignal::~TRestRawSignal() {}
 /// \brief Initialization of TRestRawSignal members
 ///
 void TRestRawSignal::Initialize() {
-    fSignalData.clear();
+
+    std::fill(fSignalData.begin(),fSignalData.end(), 0);
     fPointsOverThreshold.clear();
     fSignalID = -1;
 
@@ -114,7 +114,6 @@ void TRestRawSignal::Initialize() {
 void TRestRawSignal::Reset() {
     Int_t nBins = GetNumberOfPoints();
     Initialize();
-    for (int n = 0; n < nBins; n++) fSignalData.push_back(0);
 }
 
 ///////////////////////////////////////////////

--- a/src/TRestRawSignalEvent.cxx
+++ b/src/TRestRawSignalEvent.cxx
@@ -87,7 +87,7 @@ void TRestRawSignalEvent::Initialize() {
     fMaxTime = -1E10;
 }
 
-void TRestRawSignalEvent::AddSignal(TRestRawSignal s) {
+void TRestRawSignalEvent::AddSignal(TRestRawSignal &s) {
     if (signalIDExists(s.GetSignalID())) {
         cout << "Warning. Signal ID : " << s.GetSignalID()
              << " already exists. Signal will not be added to signal event" << endl;
@@ -97,7 +97,7 @@ void TRestRawSignalEvent::AddSignal(TRestRawSignal s) {
     s.CalculateBaseLine(fBaseLineRange.X(), fBaseLineRange.Y());
     s.SetRange(fRange);
 
-    fSignal.push_back(s);
+    fSignal.emplace_back(s);
 }
 
 void TRestRawSignalEvent::RemoveSignalWithId(Int_t sId) {


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![7](https://badgen.net/badge/Size/7/orange) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/RawSignalOpt/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/RawSignalOpt) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- Avoid push_back on TRestRawSignal constructor, now the size of the vector is fixed in the constructor.
- Using `std::fill` to set the vector to 0 at `Initialize()`
- Passing `TRestRawSignal` as reference on `TRestRawSignalEvent::AddSignal(TRestRawSignal &s)` to avoid un-necessary copies and also moving to `emplace_back` instead of `push_back`

I believe the code can be optimized further, perhaps in another review.