### PR TITLE
pipeline/fit.C relaxing good fit condition

### DIFF
--- a/pipeline/processes/fit/fit.C
+++ b/pipeline/processes/fit/fit.C
@@ -28,7 +28,7 @@ Int_t fit(Bool_t draw = false) {
     cout << "Amplitude: " << fit->GetAmplitude() << endl;
     cout << "Shaping: " << fit->GetShaping() << endl;
     cout << "Start position: " << fit->GetStartPosition() << endl;
-    
+
     TF1* f = new TF1("fit1",
                      "[0]+[1]*TMath::Exp(-3. * (x-[3])/[2]) * "
                      "(x-[3])/[2] * (x-[3])/[2] * (x-[3])/[2] * "
@@ -63,19 +63,18 @@ Int_t fit(Bool_t draw = false) {
         }
         h->Draw("hist");
     }
-    
+
     Double_t sum = 0;
-    for (int i = 0; i < shapedEvent->GetSignal(0)->GetNumberOfPoints(); i++){
-        sum+=abs(shapedEvent->GetSignal(0)->GetRawData(i) - f->Eval(i));
+    for (int i = 0; i < shapedEvent->GetSignal(0)->GetNumberOfPoints(); i++) {
+        sum += abs(shapedEvent->GetSignal(0)->GetRawData(i) - f->Eval(i));
     }
-    
+
     cout << "Absolute value of difference original-fitted: " << sum << endl;
-    
-    if (sum > 5000){
+
+    if (sum > 15000) {
         cout << "Probably fitted fuction far from original." << endl;
         return 1;
     }
-    
 
     cout << "[\033[92m OK \x1b[0m]" << endl;
     return 0;


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![7](https://badgen.net/badge/Size/7/orange) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/fit_validation_fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/fit_validation_fix) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

I had to release the condition given at the validation, because the fit launches a MC and it does not get always the same result.