### PR TITLE
Reverts TRestRawSignal updates

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -47,7 +47,7 @@ build:
   script:
     - echo "**${CI_PROJECT_DIR}**"
     - rm -rf ${CI_PROJECT_DIR}/install
-    - git clone --single-branch --branch development https://github.com/rest-for-physics/framework.git framework
+    - git clone --single-branch --branch master https://github.com/rest-for-physics/framework.git framework
     - cd framework
     - git submodule init source/libraries/raw
     - git submodule update source/libraries/raw

--- a/inc/TRestRawSignalEvent.h
+++ b/inc/TRestRawSignalEvent.h
@@ -61,7 +61,7 @@ class TRestRawSignalEvent : public TRestEvent {
     }
 
     // Setters
-    void AddSignal(TRestRawSignal &s);
+    void AddSignal(TRestRawSignal s);
 
     void RemoveSignalWithId(Int_t sId);
 

--- a/src/TRestRawSignal.cxx
+++ b/src/TRestRawSignal.cxx
@@ -77,11 +77,12 @@ TRestRawSignal::TRestRawSignal() {
 /// \brief Default constructor initializing fSignalData with a number of points
 /// equal to nBins.
 ///
-TRestRawSignal::TRestRawSignal(Int_t nBins) : fSignalData(nBins) {
-    fGraph = nullptr;
+TRestRawSignal::TRestRawSignal(Int_t nBins) {
+    fGraph = NULL;
 
     Initialize();
 
+    for (int n = 0; n < nBins; n++) fSignalData.push_back(0);
 }
 
 ///////////////////////////////////////////////
@@ -93,8 +94,7 @@ TRestRawSignal::~TRestRawSignal() {}
 /// \brief Initialization of TRestRawSignal members
 ///
 void TRestRawSignal::Initialize() {
-
-    std::fill(fSignalData.begin(),fSignalData.end(), 0);
+    fSignalData.clear();
     fPointsOverThreshold.clear();
     fSignalID = -1;
 
@@ -114,6 +114,7 @@ void TRestRawSignal::Initialize() {
 void TRestRawSignal::Reset() {
     Int_t nBins = GetNumberOfPoints();
     Initialize();
+    for (int n = 0; n < nBins; n++) fSignalData.push_back(0);
 }
 
 ///////////////////////////////////////////////

--- a/src/TRestRawSignalEvent.cxx
+++ b/src/TRestRawSignalEvent.cxx
@@ -87,7 +87,7 @@ void TRestRawSignalEvent::Initialize() {
     fMaxTime = -1E10;
 }
 
-void TRestRawSignalEvent::AddSignal(TRestRawSignal &s) {
+void TRestRawSignalEvent::AddSignal(TRestRawSignal s) {
     if (signalIDExists(s.GetSignalID())) {
         cout << "Warning. Signal ID : " << s.GetSignalID()
              << " already exists. Signal will not be added to signal event" << endl;
@@ -97,7 +97,7 @@ void TRestRawSignalEvent::AddSignal(TRestRawSignal &s) {
     s.CalculateBaseLine(fBaseLineRange.X(), fBaseLineRange.Y());
     s.SetRange(fRange);
 
-    fSignal.emplace_back(s);
+    fSignal.push_back(s);
 }
 
 void TRestRawSignalEvent::RemoveSignalWithId(Int_t sId) {


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![9](https://badgen.net/badge/Size/9/orange) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/revert_rawsignal/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/revert_rawsignal) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

It seems the updates in TRestRawSignal is provoking the `trexdm_pipeline` to fail. This PR reverts those changes.

The reason why we did not detect this promptly is because when pushing to `rawlib` the validation chain at the framework was not running, since there was no commits.

From the time being I have scheduled the pipeline at `framework` to be run everyday. However, the framework pipeline will only check against new updates in `master` submodules. Changes will not be evaluated till we merge!

A solution is to create a branch at the framework with the same name, and launch the pipeline manually :(