### PR TITLE
Optimization of TRestRawSignal

### DIFF
--- a/inc/TRestRawSignalEvent.h
+++ b/inc/TRestRawSignalEvent.h
@@ -61,7 +61,7 @@ class TRestRawSignalEvent : public TRestEvent {
     }
 
     // Setters
-    void AddSignal(TRestRawSignal s);
+    void AddSignal(TRestRawSignal &s);
 
     void RemoveSignalWithId(Int_t sId);
 

--- a/src/TRestRawSignal.cxx
+++ b/src/TRestRawSignal.cxx
@@ -82,7 +82,8 @@ TRestRawSignal::TRestRawSignal(Int_t nBins) {
 
     Initialize();
 
-    for (int n = 0; n < nBins; n++) fSignalData.push_back(0);
+    fSignalData.resize(nBins,0);
+
 }
 
 ///////////////////////////////////////////////
@@ -114,7 +115,7 @@ void TRestRawSignal::Initialize() {
 void TRestRawSignal::Reset() {
     Int_t nBins = GetNumberOfPoints();
     Initialize();
-    for (int n = 0; n < nBins; n++) fSignalData.push_back(0);
+    fSignalData.resize(nBins,0);
 }
 
 ///////////////////////////////////////////////

--- a/src/TRestRawSignalEvent.cxx
+++ b/src/TRestRawSignalEvent.cxx
@@ -87,7 +87,7 @@ void TRestRawSignalEvent::Initialize() {
     fMaxTime = -1E10;
 }
 
-void TRestRawSignalEvent::AddSignal(TRestRawSignal s) {
+void TRestRawSignalEvent::AddSignal(TRestRawSignal &s) {
     if (signalIDExists(s.GetSignalID())) {
         cout << "Warning. Signal ID : " << s.GetSignalID()
              << " already exists. Signal will not be added to signal event" << endl;
@@ -97,7 +97,7 @@ void TRestRawSignalEvent::AddSignal(TRestRawSignal s) {
     s.CalculateBaseLine(fBaseLineRange.X(), fBaseLineRange.Y());
     s.SetRange(fRange);
 
-    fSignal.push_back(s);
+    fSignal.emplace_back(s);
 }
 
 void TRestRawSignalEvent::RemoveSignalWithId(Int_t sId) {


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![6](https://badgen.net/badge/Size/6/orange) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/RawSignalOpt2/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/RawSignalOpt2) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- Avoid `push_back` on TRestRawSignal, moving to `resize` instead, note that the validation was failing in a similar pull request. From my understanding, the issue was while removing the `clear` of the vector at `Initialize`.
- Passing `TRestRawSignal` as reference on `TRestRawSignalEvent::AddSignal(TRestRawSignal &s)` to avoid un-necessary copies and also moving to emplace_back` instead of `push_back`.