### PR TITLE
Update metadata parameters for GeneralFit pipeline.

### DIFF
--- a/pipeline/processes/fit/metadata.rml
+++ b/pipeline/processes/fit/metadata.rml
@@ -2,7 +2,7 @@
 
 <TRestRawSignalShapingProcess shapingType="shaperSin" shapingTime="75" shapingGain="400" />
 
-<TRestRawSignalAddNoiseProcess noiseLevel="150"/>
+<TRestRawSignalAddNoiseProcess noiseLevel="50"/>
 
 <TRestRawSignalFittingProcess verboseLevel="debug" />
 


### PR DESCRIPTION
![DavidDiezIb](https://badgen.net/badge/PR%20submitted%20by%3A/DavidDiezIb/blue) ![1](https://badgen.net/badge/Size/1/orange) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/GeneralFit_pipeline/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/GeneralFit_pipeline) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Noise parameter reduced in metadata.rml in order to avoid pipeline failures. 