### PR TITLE
readtime reading of binary files

### DIFF
--- a/inc/TRestRawMultiCoBoAsAdToSignalProcess.h
+++ b/inc/TRestRawMultiCoBoAsAdToSignalProcess.h
@@ -126,8 +126,9 @@ class TRestRawMultiCoBoAsAdToSignalProcess : public TRestRawToSignalProcess {
 
     bool ReadFrameHeader(CoBoHeaderFrame& Frame);
 
-    bool ReadFrameDataP(FILE* f, CoBoHeaderFrame& hdr);
+    bool ReadFrameDataP(int fileid, CoBoHeaderFrame& hdr);
     bool ReadFrameDataF(CoBoHeaderFrame& hdr);
+    void CloseFile(int fileid);
 
     Bool_t EndReading();
 

--- a/inc/TRestRawToSignalProcess.h
+++ b/inc/TRestRawToSignalProcess.h
@@ -38,6 +38,7 @@ class TRestRawToSignalProcess : public TRestEventProcess {
     Double_t tStart;
     Long64_t totalBytesReaded;
     Long64_t totalBytes;
+    Int_t fMaxWaitTimeEOF;  // wait for xx seconds at eof before really closing the binary file
 
     TRestRawSignalEvent* fSignalEvent = 0;  //!
 #ifndef __CINT__
@@ -70,6 +71,7 @@ class TRestRawToSignalProcess : public TRestEventProcess {
 
     void SetRunOrigin(Int_t run_origin) { fRunOrigin = run_origin; }
     void SetSubRunOrigin(Int_t sub_run_origin) { fSubRunOrigin = sub_run_origin; }
+    bool FRead(void* ptr, size_t size, size_t n, FILE* file);
 
     void LoadConfig(std::string cfgFilename, std::string name = "");
 


### PR DESCRIPTION
I added a method `FRead()` in `TRestRawToSignalProcess` to replace the default `fread()`. It can:
* wait specific times if the file reading reaches eof
* add readed bytes count automatically

Now with the help of this method, `TRestRawMultiCoBoAsAdToSignalProcess` is able to process data when the file is still writing.