### PR TITLE
fixed TRestRawSignal::IsADCSaturation

### DIFF
--- a/inc/TRestRawSignal.h
+++ b/inc/TRestRawSignal.h
@@ -190,7 +190,7 @@ class TRestRawSignal : public TObject {
 
     Int_t GetMinPeakBin();
 
-    Bool_t IsACDSaturation(int Nflat = 3, int OverThres = 3600);
+    Bool_t IsADCSaturation(int Nflat = 3);
 
     void GetDifferentialSignal(TRestRawSignal* diffSgnl, Int_t smearPoints);
 

--- a/src/TRestRawSignal.cxx
+++ b/src/TRestRawSignal.cxx
@@ -528,17 +528,21 @@ Int_t TRestRawSignal::GetMinPeakBin() {
 ///////////////////////////////////////////////
 /// \brief It returns whether the signal has ADC saturation
 ///
-Bool_t TRestRawSignal::IsACDSaturation(int Nflat, int OverThres) {
+Bool_t TRestRawSignal::IsADCSaturation(int Nflat) {
+    if (Nflat <= 0) return false;
     // GetMaxPeakBin() will always find the first max peak bin if mulitple
     // bins are in same max value.
     int index = GetMaxPeakBin();
+    Short_t value = fSignalData[index];
 
-    bool sat = true;
+    bool sat = false;
     if (index + Nflat <= fSignalData.size()) {
         for (int i = index; i < index + Nflat; i++) {
-            if (fSignalData[index + i] > OverThres && fSignalData[index] == fSignalData[index + i]) {
-            } else {
-                sat = false;
+            if (fSignalData[i] != value) {
+                break;
+            }
+            if (i == index + Nflat - 1) {
+                sat = true;
             }
         }
     }

--- a/src/TRestRawSignalAnalysisProcess.cxx
+++ b/src/TRestRawSignalAnalysisProcess.cxx
@@ -396,7 +396,7 @@ TRestEvent* TRestRawSignalAnalysisProcess::ProcessEvent(TRestEvent* evInput) {
         risetime[sgnl->GetID()] = sgnl->GetRiseTime();
         peak_time[sgnl->GetID()] = sgnl->GetMaxPeakBin();
         npointsot[sgnl->GetID()] = sgnl->GetPointsOverThreshold().size();
-        if (sgnl->IsACDSaturation()) saturatedchnId.push_back(sgnl->GetID());
+        if (sgnl->IsADCSaturation()) saturatedchnId.push_back(sgnl->GetID());
     }
 
     SetObservableValue("pointsoverthres_map", npointsot);


### PR DESCRIPTION
![nkx111](https://badgen.net/badge/PR%20submitted%20by%3A/nkx111/blue) ![11](https://badgen.net/badge/Size/11/orange) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/nkx-sat-fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/nkx-sat-fix) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

fixed logic, fixed typo of method name.