### PR TITLE
TRestRawCommonNoiseReductionProcess: added metadata minimum number of…

### DIFF
--- a/inc/TRestRawCommonNoiseReductionProcess.h
+++ b/inc/TRestRawCommonNoiseReductionProcess.h
@@ -47,7 +47,7 @@ class TRestRawCommonNoiseReductionProcess : public TRestEventProcess {
     Int_t fCenterWidth = 10;
 
     /// Minimum number of signals required to apply the process.
-    Int_t fNSignals = 200;
+    Int_t fMinSignalsRequired = 200;
 
     void Initialize();
 
@@ -76,7 +76,7 @@ class TRestRawCommonNoiseReductionProcess : public TRestEventProcess {
         if (fMode == 1) metadata << " --> Mode 1 activated." << endl;
         metadata << " centerWidth : " << fCenterWidth << endl;
         metadata << "blocks : [" << fBlocks << "]" << endl;
-        metadata << " Minimum number of signals : " << fNSignals << endl;
+        metadata << " Minimum number of signals : " << fMinSignalsRequired << endl;
 
         EndPrintProcess();
     }

--- a/inc/TRestRawCommonNoiseReductionProcess.h
+++ b/inc/TRestRawCommonNoiseReductionProcess.h
@@ -46,6 +46,9 @@ class TRestRawCommonNoiseReductionProcess : public TRestEventProcess {
     /// the average.
     Int_t fCenterWidth = 10;
 
+    /// Minimum number of signals required to apply the process.
+    Int_t fNSignals = 200;
+
     void Initialize();
 
     void LoadDefaultConfig();
@@ -72,7 +75,8 @@ class TRestRawCommonNoiseReductionProcess : public TRestEventProcess {
         if (fMode == 0) metadata << " --> Mode 0 activated." << endl;
         if (fMode == 1) metadata << " --> Mode 1 activated." << endl;
         metadata << " centerWidth : " << fCenterWidth << endl;
-        metadata << "blocks : [" << fBlocks << "]";
+        metadata << "blocks : [" << fBlocks << "]" << endl;
+        metadata << " Minimum number of signals : " << fNSignals << endl;
 
         EndPrintProcess();
     }

--- a/pipeline/processes/commonNoise/commonNoise.C
+++ b/pipeline/processes/commonNoise/commonNoise.C
@@ -4,7 +4,7 @@ Int_t commonNoise() {
     TRestRawSignal* sgnl = new TRestRawSignal();
     for (int n = 0; n < 512; n++) sgnl->AddPoint((Short_t)(50 * TMath::Sin(2 * TMath::Pi() * n / 200)));
 
-    for (int n = 0; n < 20; n++) {
+    for (int n = 0; n < 205; n++) {
         sgnl->SetID(n);
         ev->AddSignal(*sgnl);
     }

--- a/src/TRestRawCommonNoiseReductionProcess.cxx
+++ b/src/TRestRawCommonNoiseReductionProcess.cxx
@@ -166,7 +166,7 @@ void TRestRawCommonNoiseReductionProcess::InitProcess() {}
 TRestEvent* TRestRawCommonNoiseReductionProcess::ProcessEvent(TRestEvent* evInput) {
     fInputEvent = (TRestRawSignalEvent*)evInput;
 
-    if( fInputEvent->GetNumberOfSignals() < fNSignals ){
+    if( fInputEvent->GetNumberOfSignals() < fMinSignalsRequired ){
         for (int sgnl = 0; sgnl < fInputEvent->GetNumberOfSignals(); sgnl++) {
             fOutputEvent->AddSignal(*fInputEvent->GetSignal(sgnl));
         }

--- a/src/TRestRawCommonNoiseReductionProcess.cxx
+++ b/src/TRestRawCommonNoiseReductionProcess.cxx
@@ -166,129 +166,51 @@ void TRestRawCommonNoiseReductionProcess::InitProcess() {}
 TRestEvent* TRestRawCommonNoiseReductionProcess::ProcessEvent(TRestEvent* evInput) {
     fInputEvent = (TRestRawSignalEvent*)evInput;
 
-    // Event base line determination.
-    Double_t baseLineMean = 0;
-    for (int sgnl = 0; sgnl < fInputEvent->GetNumberOfSignals(); sgnl++) {
-        fInputEvent->GetSignal(sgnl)->CalculateBaseLine(20, 150);
-        Double_t baseline = fInputEvent->GetSignal(sgnl)->GetBaseLine();
-        baseLineMean += baseline;
-    }
-    Double_t Baseline = baseLineMean / fInputEvent->GetNumberOfSignals();
+    if (fInputEvent->GetNumberOfSignals() > fNSignals) {
 
-    if (fBlocks == 0) {
-        Int_t N = fInputEvent->GetNumberOfSignals();
-
-        // if (GetVerboseLevel() >= REST_Debug) N = 1;
-        for (int sgnl = 0; sgnl < N; sgnl++) {
-            fOutputEvent->AddSignal(*fInputEvent->GetSignal(sgnl));
+        // Event base line determination.
+        Double_t baseLineMean = 0;
+        for (int sgnl = 0; sgnl < fInputEvent->GetNumberOfSignals(); sgnl++) {
+            fInputEvent->GetSignal(sgnl)->CalculateBaseLine(20, 150);
+            Double_t baseline = fInputEvent->GetSignal(sgnl)->GetBaseLine();
+            baseLineMean += baseline;
         }
+        Double_t Baseline = baseLineMean / fInputEvent->GetNumberOfSignals();
 
-        Int_t nBins = fInputEvent->GetSignal(0)->GetNumberOfPoints();
-        Int_t begin, end;
-        Double_t norm = 1.0;
-        vector<Double_t> sgnlValues(N, 0.0);
+        if (fBlocks == 0) {
+            Int_t N = fInputEvent->GetNumberOfSignals();
 
-        for (Int_t bin = 0; bin < nBins; bin++) {
-            for (Int_t sgnl = 0; sgnl < N; sgnl++) {
-                sgnlValues[sgnl] = fOutputEvent->GetSignal(sgnl)->GetRawData(bin);
-            }
-
-            std::sort(sgnlValues.begin(), sgnlValues.end());
-
-            // Sorting the different methods
-            Int_t begin, middle, end;
-            middle = (Int_t)N / 2;
-            Double_t norm = 1.0;
-
-            if (fMode == 0) {
-                // We take only the middle one
-                begin = (Int_t)((double_t)N / 2.0);
-                end = begin;
-                norm = 1.;
-            } else if (fMode == 1) {
-                // We take the average of the TRestDetectorSignals at the Center
-                begin = middle - (Int_t)(N * fCenterWidth * 0.01);
-                end = middle + (Int_t)(N * fCenterWidth * 0.01);
-                norm = (Double_t)end - begin;
-            }
-
-            // Calculation of the correction to be made to each TRestRawSignal
-            Double_t binCorrection = 0.0;
-            for (Int_t i = begin; i <= end; i++) binCorrection += sgnlValues[i];
-
-            binCorrection = binCorrection / norm;
-
-            // Correction applied.
-            for (Int_t sgnl = 0; sgnl < N; sgnl++)
-                fOutputEvent->GetSignal(sgnl)->IncreaseBinBy(bin, Baseline - binCorrection);
-        }
-
-        return fOutputEvent;
-    } else if (fBlocks == 1) {
-        Int_t N = 68;
-        Int_t nBlocks = 8;
-        Int_t firstID = 578;
-        Int_t gap = 4;
-
-        Int_t firstInBlock;
-        Int_t nSign;
-        Int_t sigID;
-
-        for (int block = 0; block < nBlocks; block++) {
-            firstInBlock = firstID + block * (N + gap);
-            nSign = 0;
             // if (GetVerboseLevel() >= REST_Debug) N = 1;
-
-            for (Int_t sgnl = 0; sgnl < N; sgnl++) {
-                sigID = firstInBlock + sgnl;
-                fInputEvent->GetSignalById(sigID)->CalculateBaseLine(20, 500);
-                if (fInputEvent->GetSignalById(sigID)->GetBaseLineSigma() >= 3.3) {
-                    // debug << "Baseline1: " <<
-                    // fInputEvent->GetSignalById(sigID)->GetBaseLineSigma() <<
-                    // endl;
-                    fOutputEvent->AddSignal(*fInputEvent->GetSignalById(sigID));
-                    nSign++;
-                }
+            for (int sgnl = 0; sgnl < N; sgnl++) {
+                fOutputEvent->AddSignal(*fInputEvent->GetSignal(sgnl));
             }
 
             Int_t nBins = fInputEvent->GetSignal(0)->GetNumberOfPoints();
             Int_t begin, end;
             Double_t norm = 1.0;
-            vector<Double_t> sgnlValues(nSign, 0.0);
-
-            // debug << "nSign: " << nSign << endl;
+            vector<Double_t> sgnlValues(N, 0.0);
 
             for (Int_t bin = 0; bin < nBins; bin++) {
-                int i = 0;
                 for (Int_t sgnl = 0; sgnl < N; sgnl++) {
-                    sigID = firstInBlock + sgnl;
-                    if (fInputEvent->GetSignalById(sigID)->GetBaseLineSigma() >= 3.3) {
-                        // debug << "Baseline2: " <<
-                        // fInputEvent->GetSignalById(sigID)->GetBaseLineSigma() <<
-                        // endl;
-                        // debug << fOutputEvent->GetSignalById(sigID)->GetRawData(bin) <<
-                        // endl;
-                        sgnlValues[i] = fOutputEvent->GetSignalById(sigID)->GetRawData(bin);
-                        i++;
-                    }
+                    sgnlValues[sgnl] = fOutputEvent->GetSignal(sgnl)->GetRawData(bin);
                 }
 
                 std::sort(sgnlValues.begin(), sgnlValues.end());
 
                 // Sorting the different methods
                 Int_t begin, middle, end;
-                middle = (Int_t)nSign / 2;
+                middle = (Int_t)N / 2;
                 Double_t norm = 1.0;
 
                 if (fMode == 0) {
                     // We take only the middle one
-                    begin = (Int_t)((double_t)nSign / 2.0);
+                    begin = (Int_t)((double_t)N / 2.0);
                     end = begin;
                     norm = 1.;
                 } else if (fMode == 1) {
                     // We take the average of the TRestDetectorSignals at the Center
-                    begin = middle - (Int_t)(nSign * fCenterWidth * 0.01);
-                    end = middle + (Int_t)(nSign * fCenterWidth * 0.01);
+                    begin = middle - (Int_t)(N * fCenterWidth * 0.01);
+                    end = middle + (Int_t)(N * fCenterWidth * 0.01);
                     norm = (Double_t)end - begin;
                 }
 
@@ -299,18 +221,104 @@ TRestEvent* TRestRawCommonNoiseReductionProcess::ProcessEvent(TRestEvent* evInpu
                 binCorrection = binCorrection / norm;
 
                 // Correction applied.
+                for (Int_t sgnl = 0; sgnl < N; sgnl++)
+                    fOutputEvent->GetSignal(sgnl)->IncreaseBinBy(bin, Baseline - binCorrection);
+            }
+
+            return fOutputEvent;
+        } else if (fBlocks == 1) {
+            Int_t N = 68;
+            Int_t nBlocks = 8;
+            Int_t firstID = 578;
+            Int_t gap = 4;
+
+            Int_t firstInBlock;
+            Int_t nSign;
+            Int_t sigID;
+
+            for (int block = 0; block < nBlocks; block++) {
+                firstInBlock = firstID + block * (N + gap);
+                nSign = 0;
+                // if (GetVerboseLevel() >= REST_Debug) N = 1;
+
                 for (Int_t sgnl = 0; sgnl < N; sgnl++) {
-                    if (fInputEvent->GetSignalById(firstInBlock + sgnl)->GetBaseLineSigma() >= 3.3) {
-                        fOutputEvent->GetSignalById(firstInBlock + sgnl)
-                            ->IncreaseBinBy(bin, Baseline - binCorrection);
+                    sigID = firstInBlock + sgnl;
+                    fInputEvent->GetSignalById(sigID)->CalculateBaseLine(20, 500);
+                    if (fInputEvent->GetSignalById(sigID)->GetBaseLineSigma() >= 3.3) {
+                        // debug << "Baseline1: " <<
+                        // fInputEvent->GetSignalById(sigID)->GetBaseLineSigma() <<
+                        // endl;
+                        fOutputEvent->AddSignal(*fInputEvent->GetSignalById(sigID));
+                        nSign++;
+                    }
+                }
+
+                Int_t nBins = fInputEvent->GetSignal(0)->GetNumberOfPoints();
+                Int_t begin, end;
+                Double_t norm = 1.0;
+                vector<Double_t> sgnlValues(nSign, 0.0);
+
+                // debug << "nSign: " << nSign << endl;
+
+                for (Int_t bin = 0; bin < nBins; bin++) {
+                    int i = 0;
+                    for (Int_t sgnl = 0; sgnl < N; sgnl++) {
+                        sigID = firstInBlock + sgnl;
+                        if (fInputEvent->GetSignalById(sigID)->GetBaseLineSigma() >= 3.3) {
+                            // debug << "Baseline2: " <<
+                            // fInputEvent->GetSignalById(sigID)->GetBaseLineSigma() <<
+                            // endl;
+                            // debug << fOutputEvent->GetSignalById(sigID)->GetRawData(bin) <<
+                            // endl;
+                            sgnlValues[i] = fOutputEvent->GetSignalById(sigID)->GetRawData(bin);
+                            i++;
+                        }
+                    }
+
+                    std::sort(sgnlValues.begin(), sgnlValues.end());
+
+                    // Sorting the different methods
+                    Int_t begin, middle, end;
+                    middle = (Int_t)nSign / 2;
+                    Double_t norm = 1.0;
+
+                    if (fMode == 0) {
+                        // We take only the middle one
+                        begin = (Int_t)((double_t)nSign / 2.0);
+                        end = begin;
+                        norm = 1.;
+                    } else if (fMode == 1) {
+                        // We take the average of the TRestDetectorSignals at the Center
+                        begin = middle - (Int_t)(nSign * fCenterWidth * 0.01);
+                        end = middle + (Int_t)(nSign * fCenterWidth * 0.01);
+                        norm = (Double_t)end - begin;
+                    }
+
+                    // Calculation of the correction to be made to each TRestRawSignal
+                    Double_t binCorrection = 0.0;
+                    for (Int_t i = begin; i <= end; i++) binCorrection += sgnlValues[i];
+
+                    binCorrection = binCorrection / norm;
+
+                    // Correction applied.
+                    for (Int_t sgnl = 0; sgnl < N; sgnl++) {
+                        if (fInputEvent->GetSignalById(firstInBlock + sgnl)->GetBaseLineSigma() >= 3.3) {
+                            fOutputEvent->GetSignalById(firstInBlock + sgnl)
+                                ->IncreaseBinBy(bin, Baseline - binCorrection);
+                        }
+                    }
+                }
+                for (int sgnl = 0; sgnl < N; sgnl++) {
+                    if (fInputEvent->GetSignalById(firstInBlock + sgnl)->GetBaseLineSigma() < 3.3) {
+                        fOutputEvent->AddSignal(*fInputEvent->GetSignalById(firstInBlock + sgnl));
                     }
                 }
             }
-            for (int sgnl = 0; sgnl < N; sgnl++) {
-                if (fInputEvent->GetSignalById(firstInBlock + sgnl)->GetBaseLineSigma() < 3.3) {
-                    fOutputEvent->AddSignal(*fInputEvent->GetSignalById(firstInBlock + sgnl));
-                }
-            }
+        }
+        return fOutputEvent;
+    } else {
+        for (int sgnl = 0; sgnl < fInputEvent->GetNumberOfSignals(); sgnl++) {
+            fOutputEvent->AddSignal(*fInputEvent->GetSignal(sgnl));
         }
         return fOutputEvent;
     }


### PR DESCRIPTION
![cmargalejo](https://badgen.net/badge/PR%20submitted%20by%3A/cmargalejo/blue) ![13](https://badgen.net/badge/Size/13/orange) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/commonNoiseUpdate/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/commonNoiseUpdate) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

… signals required to apply the process.

Sorry for the big _diff_.  After introducing the new ` if (fInputEvent->GetNumberOfSignals() > fNSignals)` in line 169, I just tabulated everything to the right, and it appears as a lot of changes. The `else` statement starting in line 319 is also new.