### PR TITLE
TRestRawSignalAnalysisProcess. Redefining meanRate and EventTimeDelay

### DIFF
--- a/inc/TRestRawSignalAnalysisProcess.h
+++ b/inc/TRestRawSignalAnalysisProcess.h
@@ -36,6 +36,7 @@ class TRestRawSignalAnalysisProcess : public TRestEventProcess {
 
     Double_t fFirstEventTime;             //!
     vector<Double_t> fPreviousEventTime;  //!
+    vector<Double_t> fPreviousEventId;    //!
 
     time_t timeStored;  //!
 


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![16](https://badgen.net/badge/Size/16/orange) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/mean_rate_fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/mean_rate_fix)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR is to address the issue raised at rest-for-physics/framework#126. It seems some observables are not thread safe.

Redefining the mean rate calculation using the event id should produce more reliable results. However, this might depend on the electronics producing the good event ordering. I.e. empty events generating additional event ids may derive on overestimated rates.