### PR TITLE
Fixing bug on inheritance of DrawEvent from base class

### DIFF
--- a/inc/TRestRawSignalEvent.h
+++ b/inc/TRestRawSignalEvent.h
@@ -146,7 +146,7 @@ class TRestRawSignalEvent : public TRestEvent {
     void Initialize();
     void PrintEvent();
 
-    TPad* DrawEvent(TString option = "");
+    TPad* DrawEvent(const TString& option = "");
     TPad* DrawSignal(Int_t signal, TString option = "");
 
     // Constructor

--- a/src/TRestRawSignalEvent.cxx
+++ b/src/TRestRawSignalEvent.cxx
@@ -395,7 +395,7 @@ Double_t TRestRawSignalEvent::GetMaxTime() {
 /// DrawEvent("ids[800,900]:printIDs");
 /// \endcode
 ///
-TPad* TRestRawSignalEvent::DrawEvent(TString option) {
+TPad* TRestRawSignalEvent::DrawEvent(const TString& option) {
     int nSignals = this->GetNumberOfSignals();
 
     if (fPad != nullptr) {


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![2](https://badgen.net/badge/Size/2/orange) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/DrawEventFix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/DrawEventFix)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

After new changes in the code, it seems that `DrawEvent` is not working for some inherited classes from `TRestEvent`

This PR fix this bug by replacing:
```
- TPad* DrawEvent(TString option = "");
+ TPad* DrawEvent(const TString& option = "");
```