### PR TITLE
TRestRawSignalRecoverChannelsProcess: bug fix

### DIFF
--- a/src/TRestRawSignalRecoverChannelsProcess.cxx
+++ b/src/TRestRawSignalRecoverChannelsProcess.cxx
@@ -175,6 +175,8 @@ TRestEvent* TRestRawSignalRecoverChannelsProcess::ProcessEvent(TRestEvent* evInp
         // cout << "Channel id : " << fChannelIds[x] << " Left : " << idL << " Right
         // : " << idR << endl;
 
+        fOutputSignalEvent->RemoveSignalWithId(fChannelIds[x]);
+
         if (idL == -1 || idR == -1) continue;
 
         TRestRawSignal* leftSgnl = fInputSignalEvent->GetSignalById(idL);

--- a/src/TRestRawSignalRecoverChannelsProcess.cxx
+++ b/src/TRestRawSignalRecoverChannelsProcess.cxx
@@ -175,7 +175,7 @@ TRestEvent* TRestRawSignalRecoverChannelsProcess::ProcessEvent(TRestEvent* evInp
         // cout << "Channel id : " << fChannelIds[x] << " Left : " << idL << " Right
         // : " << idR << endl;
 
-        fOutputSignalEvent->RemoveSignalWithId(fChannelIds[x]);
+        if( fOutputSignalEvent->GetSignalIndex(fChannelIds[x])> 0 ) fOutputSignalEvent->RemoveSignalWithId(fChannelIds[x]);
 
         if (idL == -1 || idR == -1) continue;
 


### PR DESCRIPTION
![KonradAltenmueller](https://badgen.net/badge/PR%20submitted%20by%3A/KonradAltenmueller/blue) ![Ok: 2](https://badgen.net/badge/PR%20Size/Ok%3A%202/green) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/konrad_update/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/konrad_update) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/konrad_update/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/konrad_update)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fixed a bug, where an error was produced when running `TRestRawSignalRecoverChannelsProcess` on data, where all channels were read out , because the recovered signal would overwrite an existing noise signal in the dead channel.