### PR TITLE
Renaming endl to RESTendl and other logger functions

### DIFF
--- a/inc/TRestRawBaseLineCorrectionProcess.h
+++ b/inc/TRestRawBaseLineCorrectionProcess.h
@@ -56,8 +56,8 @@ class TRestRawBaseLineCorrectionProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << "Smoothing window size: " << fSmoothingWindow << endl;
-        metadata << "Baseline correction applied to signals with IDs in range (" << fSignalsRange.X() << "," << fSignalsRange.Y() << ")" << endl;
+        RESTMetadata << "Smoothing window size: " << fSmoothingWindow << RESTendl;
+        RESTMetadata << "Baseline correction applied to signals with IDs in range (" << fSignalsRange.X() << "," << fSignalsRange.Y() << ")" << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestRawCommonNoiseReductionProcess.h
+++ b/inc/TRestRawCommonNoiseReductionProcess.h
@@ -72,12 +72,12 @@ class TRestRawCommonNoiseReductionProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << " mode : [" << fMode << "]";
-        if (fMode == 0) metadata << " --> Mode 0 activated." << endl;
-        if (fMode == 1) metadata << " --> Mode 1 activated." << endl;
-        metadata << " centerWidth : " << fCenterWidth << endl;
-        metadata << "blocks : [" << fBlocks << "]" << endl;
-        metadata << " Minimum number of signals : " << fMinSignalsRequired << endl;
+        RESTMetadata << " mode : [" << fMode << "]";
+        if (fMode == 0) RESTMetadata << " --> Mode 0 activated." << RESTendl;
+        if (fMode == 1) RESTMetadata << " --> Mode 1 activated." << RESTendl;
+        RESTMetadata << " centerWidth : " << fCenterWidth << RESTendl;
+        RESTMetadata << "blocks : [" << fBlocks << "]" << RESTendl;
+        RESTMetadata << " Minimum number of signals : " << fMinSignalsRequired << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestRawMultiCoBoAsAdToSignalProcess.h
+++ b/inc/TRestRawMultiCoBoAsAdToSignalProcess.h
@@ -77,20 +77,20 @@ struct CoBoHeaderFrame {
     // int fEveTimeNanoSec;
 
     void Show() {
-        std::cout << "------ Frame Header ------" << endl;
-        std::cout << "frameSize " << frameSize << endl;
+        std::cout << "------ Frame Header ------" << std::endl;
+        std::cout << "frameSize " << frameSize << std::endl;
 
-        std::cout << "frameType " << frameType << endl;
-        std::cout << "revision " << revision << endl;
-        std::cout << "headerSize " << headerSize << endl;
-        std::cout << "itemSize " << itemSize << endl;
-        std::cout << "nItems " << nItems << endl;
-        std::cout << "eventTime " << eventTime << endl;
-        std::cout << "eventIdx " << eventIdx << endl;
+        std::cout << "frameType " << frameType << std::endl;
+        std::cout << "revision " << revision << std::endl;
+        std::cout << "headerSize " << headerSize << std::endl;
+        std::cout << "itemSize " << itemSize << std::endl;
+        std::cout << "nItems " << nItems << std::endl;
+        std::cout << "eventTime " << eventTime << std::endl;
+        std::cout << "eventIdx " << eventIdx << std::endl;
 
-        std::cout << "asadIdx " << asadIdx << endl;
-        std::cout << "readOffset " << readOffset << endl;
-        std::cout << "status " << status << endl;
+        std::cout << "asadIdx " << asadIdx << std::endl;
+        std::cout << "readOffset " << readOffset << std::endl;
+        std::cout << "status " << status << std::endl;
     }
 };
 

--- a/inc/TRestRawSignalAddNoiseProcess.h
+++ b/inc/TRestRawSignalAddNoiseProcess.h
@@ -58,7 +58,7 @@ class TRestRawSignalAddNoiseProcess : public TRestEventProcess {
     inline void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << "Noise Level : " << fNoiseLevel << endl;
+        RESTMetadata << "Noise Level : " << fNoiseLevel << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestRawSignalAnalysisProcess.h
+++ b/inc/TRestRawSignalAnalysisProcess.h
@@ -69,13 +69,13 @@ class TRestRawSignalAnalysisProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << "Baseline range : ( " << fBaseLineRange.X() << " , " << fBaseLineRange.Y() << " ) "
-                 << endl;
-        metadata << "Integral range : ( " << fIntegralRange.X() << " , " << fIntegralRange.Y() << " ) "
-                 << endl;
-        metadata << "Point Threshold : " << fPointThreshold << " sigmas" << endl;
-        metadata << "Signal threshold : " << fSignalThreshold << " sigmas" << endl;
-        metadata << "Number of points over threshold : " << fPointsOverThreshold << endl;
+        RESTMetadata << "Baseline range : ( " << fBaseLineRange.X() << " , " << fBaseLineRange.Y() << " ) "
+                 << RESTendl;
+        RESTMetadata << "Integral range : ( " << fIntegralRange.X() << " , " << fIntegralRange.Y() << " ) "
+                 << RESTendl;
+        RESTMetadata << "Point Threshold : " << fPointThreshold << " sigmas" << RESTendl;
+        RESTMetadata << "Signal threshold : " << fSignalThreshold << " sigmas" << RESTendl;
+        RESTMetadata << "Number of points over threshold : " << fPointsOverThreshold << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestRawSignalChannelActivityProcess.h
+++ b/inc/TRestRawSignalChannelActivityProcess.h
@@ -118,19 +118,19 @@ class TRestRawSignalChannelActivityProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << "Low signal threshold activity : " << fLowThreshold << endl;
-        metadata << "High signal threshold activity : " << fHighThreshold << endl;
+        RESTMetadata << "Low signal threshold activity : " << fLowThreshold << RESTendl;
+        RESTMetadata << "High signal threshold activity : " << fHighThreshold << RESTendl;
 
-        metadata << "Number of daq histogram channels : " << fDaqChannels << endl;
-        metadata << "Start daq channel : " << fDaqStartChannel << endl;
-        metadata << "End daq channel : " << fDaqEndChannel << endl;
+        RESTMetadata << "Number of daq histogram channels : " << fDaqChannels << RESTendl;
+        RESTMetadata << "Start daq channel : " << fDaqStartChannel << RESTendl;
+        RESTMetadata << "End daq channel : " << fDaqEndChannel << RESTendl;
 
 #ifdef REST_DetectorLib
-        metadata << "Number of readout histogram channels : " << fReadoutChannels << endl;
-        metadata << "Start readout channel : " << fReadoutStartChannel << endl;
-        metadata << "End readout channel : " << fReadoutEndChannel << endl;
+        RESTMetadata << "Number of readout histogram channels : " << fReadoutChannels << RESTendl;
+        RESTMetadata << "Start readout channel : " << fReadoutStartChannel << RESTendl;
+        RESTMetadata << "End readout channel : " << fReadoutEndChannel << RESTendl;
 #else
-        metadata << "Some Detector features in this process are not available!" << endl;
+        RESTMetadata << "Some Detector features in this process are not available!" << RESTendl;
 #endif
 
         EndPrintProcess();

--- a/inc/TRestRawSignalGeneralFitProcess.h
+++ b/inc/TRestRawSignalGeneralFitProcess.h
@@ -73,8 +73,8 @@ class TRestRawSignalGeneralFitProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << "Function std::string: " << fFunction << endl;
-        metadata << "Range: ( " << fFunctionRange.X() << " , " << fFunctionRange.Y() << " ) " << endl;
+        RESTMetadata << "Function std::string: " << fFunction << RESTendl;
+        RESTMetadata << "Range: ( " << fFunctionRange.X() << " , " << fFunctionRange.Y() << " ) " << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestRawSignalRecoverChannelsProcess.h
+++ b/inc/TRestRawSignalRecoverChannelsProcess.h
@@ -44,7 +44,7 @@ class TRestRawSignalRecoverChannelsProcess : public TRestEventProcess {
     TRestDetectorReadout* fReadout;  //!
 #endif
 
-    void Initialize();
+    void Initialize() override;
 
     void LoadDefaultConfig();
 
@@ -56,16 +56,16 @@ class TRestRawSignalRecoverChannelsProcess : public TRestEventProcess {
     any GetInputEvent() const override { return fInputSignalEvent; }
     any GetOutputEvent() const override { return fOutputSignalEvent; }
 
-    void InitProcess();
-    TRestEvent* ProcessEvent(TRestEvent* eventInput);
+    void InitProcess() override;
+    TRestEvent* ProcessEvent(TRestEvent* eventInput) override;
 
     void LoadConfig(const std::string& configFilename, const std::string& name = "");
 
     /// It prints out the process parameters stored in the metadata structure
-    void PrintMetadata() {
+    void PrintMetadata() override {
         BeginPrintProcess();
         for (const auto& channelId : fChannelIds) {
-            metadata << "Channel id to recover: " << channelId << endl;
+            RESTMetadata << "Channel id to recover: " << channelId << RESTendl;
         }
         EndPrintProcess();
     }
@@ -83,6 +83,6 @@ class TRestRawSignalRecoverChannelsProcess : public TRestEventProcess {
     // Destructor
     ~TRestRawSignalRecoverChannelsProcess();
 
-    ClassDef(TRestRawSignalRecoverChannelsProcess, 1);
+    ClassDefOverride(TRestRawSignalRecoverChannelsProcess, 1);
 };
 #endif

--- a/inc/TRestRawSignalRemoveChannelsProcess.h
+++ b/inc/TRestRawSignalRemoveChannelsProcess.h
@@ -62,7 +62,7 @@ class TRestRawSignalRemoveChannelsProcess : public TRestEventProcess {
         BeginPrintProcess();
 
         for (unsigned int n = 0; n < fChannelIds.size(); n++)
-            metadata << "Channel id to remove : " << fChannelIds[n] << endl;
+            RESTMetadata << "Channel id to remove : " << fChannelIds[n] << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestRawSignalShapingProcess.h
+++ b/inc/TRestRawSignalShapingProcess.h
@@ -73,11 +73,11 @@ class TRestRawSignalShapingProcess : public TRestEventProcess {
     inline void PrintMetadata() override {
         BeginPrintProcess();
 
-        metadata << "Shaping type : " << fShapingType << endl;
-        metadata << "Shaping time : " << fShapingTime << endl;
-        metadata << "Amplitude gain : " << fShapingGain << endl;
+        RESTMetadata << "Shaping type : " << fShapingType << RESTendl;
+        RESTMetadata << "Shaping time : " << fShapingTime << RESTendl;
+        RESTMetadata << "Amplitude gain : " << fShapingGain << RESTendl;
         if (fShapingType == "responseFile") {
-            metadata << "Response file : " << fResponseFilename << endl;
+            RESTMetadata << "Response file : " << fResponseFilename << RESTendl;
         }
 
         EndPrintProcess();

--- a/inc/TRestRawSignalViewerProcess.h
+++ b/inc/TRestRawSignalViewerProcess.h
@@ -65,7 +65,7 @@ class TRestRawSignalViewerProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
-        std::cout << "Refresh value : " << fDrawRefresh << endl;
+        std::cout << "Refresh value : " << fDrawRefresh << std::endl;
 
         EndPrintProcess();
     }

--- a/src/TRestRawAFTERToSignalProcess.cxx
+++ b/src/TRestRawAFTERToSignalProcess.cxx
@@ -161,10 +161,10 @@ TRestEvent* TRestRawAFTERToSignalProcess::ProcessEvent(TRestEvent* inputEvent) {
     payload = head.eventSize;
     frameBits = sizeof(head);
 
-    debug << "Event number from header --> 0x" << std::hex << head.eventNumb << std::dec << endl;
-    debug << " event header size " << sizeof(head) << endl;
-    debug << " total rawdata size 0x" << std::hex << head.eventSize << std::dec << endl;
-    debug << "Payload " << payload << endl;
+    RESTDebug << "Event number from header --> 0x" << std::hex << head.eventNumb << std::dec << RESTendl;
+    RESTDebug << " event header size " << sizeof(head) << RESTendl;
+    RESTDebug << " total rawdata size 0x" << std::hex << head.eventSize << std::dec << RESTendl;
+    RESTDebug << "Payload " << payload << RESTendl;
 
     fSignalEvent->SetID(head.eventNumb);
 
@@ -208,51 +208,51 @@ TRestEvent* TRestRawAFTERToSignalProcess::ProcessEvent(TRestEvent* inputEvent) {
             prevTime = eventTime;
             first = false;
 
-            debug << "Timestamp: " << eventTime << endl;
+            RESTDebug << "Timestamp: " << eventTime << RESTendl;
         }
 
-        debug << "******Event data packet header:******" << endl;
+        RESTDebug << "******Event data packet header:******" << RESTendl;
 
-        debug << "Size " << ntohs(pHeader.size) << endl;
+        RESTDebug << "Size " << ntohs(pHeader.size) << RESTendl;
 
-        debug << "Event data packet header: " << endl;
-        debug << std::hex << "Size 0x" << ntohs(pHeader.size) << endl;
+        RESTDebug << "Event data packet header: " << RESTendl;
+        RESTDebug << std::hex << "Size 0x" << ntohs(pHeader.size) << RESTendl;
 #ifdef NEW_DAQ_T2K_2_X
-        debug << "DCC 0x" << ntohs(pHeader.dcc) << endl;
+        RESTDebug << "DCC 0x" << ntohs(pHeader.dcc) << RESTendl;
 #endif
-        debug << "Hdr word 0x" << ntohs(pHeader.hdr) << endl;
-        debug << "Args 0x" << ntohs(pHeader.args) << endl;
-        debug << "TS_H 0x" << ntohs(pHeader.ts_h) << endl;
-        debug << "TS_L 0x" << ntohs(pHeader.ts_l) << endl;
-        debug << "Ecnt 0x" << ntohs(pHeader.ecnt) << endl;
-        debug << "Scnt 0x" << ntohs(pHeader.scnt) << std::dec << endl;
+        RESTDebug << "Hdr word 0x" << ntohs(pHeader.hdr) << RESTendl;
+        RESTDebug << "Args 0x" << ntohs(pHeader.args) << RESTendl;
+        RESTDebug << "TS_H 0x" << ntohs(pHeader.ts_h) << RESTendl;
+        RESTDebug << "TS_L 0x" << ntohs(pHeader.ts_l) << RESTendl;
+        RESTDebug << "Ecnt 0x" << ntohs(pHeader.ecnt) << RESTendl;
+        RESTDebug << "Scnt 0x" << ntohs(pHeader.scnt) << std::dec << RESTendl;
 
 #ifdef NEW_DAQ_T2K_2_X
-        debug << "RawDCC Head 0x" << std::hex << ntohs(pHeader.dcc) << std::dec << " Version "
+        RESTDebug << "RawDCC Head 0x" << std::hex << ntohs(pHeader.dcc) << std::dec << " Version "
               << GET_EVENT_TYPE(ntohs(pHeader.dcc));
-        debug << " Flag " << ((ntohs(pHeader.dcc) & 0x3000) >> 12);
-        debug << " RT " << ((ntohs(pHeader.dcc) & 0x0C00) >> 10) << " DCCInd "
+        RESTDebug << " Flag " << ((ntohs(pHeader.dcc) & 0x3000) >> 12);
+        RESTDebug << " RT " << ((ntohs(pHeader.dcc) & 0x0C00) >> 10) << " DCCInd "
               << ((ntohs(pHeader.dcc) & 0x03F0) >> 4);
-        debug << " FEMInd " << (ntohs(pHeader.dcc) & 0x000F) << endl;
+        RESTDebug << " FEMInd " << (ntohs(pHeader.dcc) & 0x000F) << RESTendl;
 
-        debug << "FEM0Ind " << ntohs(pHeader.hdr) << " Type " << ((ntohs(pHeader.hdr) & 0xF000) >> 12);
-        debug << " L " << ((ntohs(pHeader.hdr) & 0x0800) >> 11);
-        debug << " U " << ((ntohs(pHeader.hdr) & 0x0800) >> 10) << " FECFlags "
+        RESTDebug << "FEM0Ind " << ntohs(pHeader.hdr) << " Type " << ((ntohs(pHeader.hdr) & 0xF000) >> 12);
+        RESTDebug << " L " << ((ntohs(pHeader.hdr) & 0x0800) >> 11);
+        RESTDebug << " U " << ((ntohs(pHeader.hdr) & 0x0800) >> 10) << " FECFlags "
               << ((ntohs(pHeader.hdr) & 0x03F0) >> 4);
-        debug << " Index " << (ntohs(pHeader.hdr) & 0x000F) << endl;
+        RESTDebug << " Index " << (ntohs(pHeader.hdr) & 0x000F) << RESTendl;
 
-        debug << "RawFEM 0x" << std::hex << ntohs(pHeader.args) << std::dec << " M "
+        RESTDebug << "RawFEM 0x" << std::hex << ntohs(pHeader.args) << std::dec << " M "
               << ((ntohs(pHeader.args) & 0x8000) >> 15);
-        debug << " N " << ((ntohs(pHeader.args) & 0x4000) >> 14) << " Zero "
+        RESTDebug << " N " << ((ntohs(pHeader.args) & 0x4000) >> 14) << " Zero "
               << ((ntohs(pHeader.args) & 0x1000) >> 13);
-        debug << " Arg2 " << GET_RB_ARG2(ntohs(pHeader.args)) << " Arg2 " << GET_RB_ARG1(ntohs(pHeader.args))
-              << endl;
-        debug << "TimeStampH " << ntohs(pHeader.ts_h) << endl;
-        debug << "TimeStampL " << ntohs(pHeader.ts_l) << endl;
-        debug << "RawEvType 0x" << std::hex << ntohs(pHeader.ecnt) << std::dec << " EvTy "
+        RESTDebug << " Arg2 " << GET_RB_ARG2(ntohs(pHeader.args)) << " Arg2 " << GET_RB_ARG1(ntohs(pHeader.args))
+              << RESTendl;
+        RESTDebug << "TimeStampH " << ntohs(pHeader.ts_h) << RESTendl;
+        RESTDebug << "TimeStampL " << ntohs(pHeader.ts_l) << RESTendl;
+        RESTDebug << "RawEvType 0x" << std::hex << ntohs(pHeader.ecnt) << std::dec << " EvTy "
               << GET_EVENT_TYPE(ntohs(pHeader.ecnt));
-        debug << " EventCount " << GET_EVENT_COUNT(ntohs(pHeader.ecnt)) << endl;
-        debug << "Samples " << ntohs(pHeader.scnt) << endl;
+        RESTDebug << " EventCount " << GET_EVENT_COUNT(ntohs(pHeader.ecnt)) << RESTendl;
+        RESTDebug << "Samples " << ntohs(pHeader.scnt) << RESTendl;
 #endif
 
         tempAsic1 = GET_RB_ARG1(ntohs(pHeader.args));
@@ -261,7 +261,7 @@ TRestEvent* TRestRawAFTERToSignalProcess::ProcessEvent(TRestEvent* inputEvent) {
         asicN = (10 * (tempAsic1 % 6) / 2 + tempAsic2) % 4;
         fecN = (10 * (tempAsic1 % 6) / 2 + tempAsic2) / 4;
 
-        debug << " channel " << channel << " asic " << asicN << " fec " << fecN << endl;
+        RESTDebug << " channel " << channel << " asic " << asicN << " fec " << fecN << RESTendl;
 
         sampleCountRead = ntohs(pHeader.scnt);
         pay = sampleCountRead % 2;
@@ -300,20 +300,20 @@ TRestEvent* TRestRawAFTERToSignalProcess::ProcessEvent(TRestEvent* inputEvent) {
             data = ntohs(dat);
 
             std::bitset<16> bs(data);
-            debug << bs << endl;
+            RESTDebug << bs << RESTendl;
 
             if (((data & 0xFE00) >> 9) == 8) {
                 timeBin = GET_CELL_INDEX(data);
                 if (timeBin == 511) isData = false;
-                debug << data << " Time bin " << timeBin << endl;
+                RESTDebug << data << " Time bin " << timeBin << RESTendl;
             } else if ((((data & 0xF000) >> 12) == 0) && isData) {
                 fSignalEvent->AddChargeToSignal(physChannel, timeBin, data);
-                debug << "Time bin " << timeBin << " ADC: " << data << endl;
+                RESTDebug << "Time bin " << timeBin << " ADC: " << data << RESTendl;
                 timeBin++;
             }
         }
 
-        debug << pay << endl;
+        RESTDebug << pay << RESTendl;
         if (pay) {
             fread(&dat, sizeof(uint16_t), 1, fInputBinFile);
             frameBits += sizeof(uint16_t);
@@ -322,15 +322,15 @@ TRestEvent* TRestRawAFTERToSignalProcess::ProcessEvent(TRestEvent* inputEvent) {
         fread(&pEnd, sizeof(DataPacketEnd), 1, fInputBinFile);
         frameBits += sizeof(DataPacketEnd);
 
-        debug << "Read "
+        RESTDebug << "Read "
               << sampleCountRead * sizeof(uint16_t) + sizeof(DataPacketHeader) + sizeof(DataPacketEnd) +
                      sampleCountRead % 2 * sizeof(uint16_t)
               << " vs HeadSize " << ntohs(pHeader.size) << " Diff "
               << ntohs(pHeader.size) - (sampleCountRead + sizeof(DataPacketHeader) + sizeof(DataPacketEnd) +
                                         sampleCountRead % 2)
-              << endl;
-        debug << "Trailer_H " << ntohs(pEnd.crc1) << " Trailer_L " << ntohs(pEnd.crc2) << endl;
-        debug << "Trailer " << eventTime << "\n" << endl;
+              << RESTendl;
+        RESTDebug << "Trailer_H " << ntohs(pEnd.crc1) << " Trailer_L " << ntohs(pEnd.crc2) << RESTendl;
+        RESTDebug << "Trailer " << eventTime << "\n" << RESTendl;
 
     }  // end while
     totalBytesReaded += frameBits;
@@ -338,7 +338,7 @@ TRestEvent* TRestRawAFTERToSignalProcess::ProcessEvent(TRestEvent* inputEvent) {
     // printf("Event ID %d time stored
     // %.3lf\n",fSignalEvent->GetID(),fSignalEvent->GetTime());
 
-    debug << "End of event " << endl;
+    RESTDebug << "End of event " << RESTendl;
 
     return fSignalEvent;
 }

--- a/src/TRestRawFEUDreamToSignalProcess.cxx
+++ b/src/TRestRawFEUDreamToSignalProcess.cxx
@@ -99,7 +99,7 @@ void TRestRawFEUDreamToSignalProcess::Initialize() {
 
 void TRestRawFEUDreamToSignalProcess::InitProcess() {
     tStart = 0;  // timeStamp of the run initially set to 0
-    info << "TRestRawFEUDreamToSignalProcess::InitProcess" << endl;
+    RESTInfo << "TRestRawFEUDreamToSignalProcess::InitProcess" << RESTendl;
 
     totalBytesReaded = 0;
 }
@@ -108,7 +108,7 @@ TRestEvent* TRestRawFEUDreamToSignalProcess::ProcessEvent(TRestEvent* inputEvent
     FeuReadOut Feu;
     bool badreadfg = false;
 
-    debug << "---------------Start of TRestRawFEUDreamToSignalProcess::ProcessEvent------------" << endl;
+    RESTDebug << "---------------Start of TRestRawFEUDreamToSignalProcess::ProcessEvent------------" << RESTendl;
 
     fSignalEvent->Initialize();
 
@@ -118,22 +118,22 @@ TRestEvent* TRestRawFEUDreamToSignalProcess::ProcessEvent(TRestEvent* inputEvent
 
         // Check header and fill Event IDs and TimeStamps
         badreadfg = ReadFeuHeaders(Feu);
-        debug << "TRestRawFEUDreamToSignalProcess::ProcessEvent: header read, badreadfg " << badreadfg
-              << endl;
-        debug << "TRestRawFEUDreamToSignalProcess::ProcessEvent: event to read EventID " << Feu.EventID
-              << " Time " << Feu.TimeStamp << " isample " << Feu.isample << endl;
+        RESTDebug << "TRestRawFEUDreamToSignalProcess::ProcessEvent: header read, badreadfg " << badreadfg
+              << RESTendl;
+        RESTDebug << "TRestRawFEUDreamToSignalProcess::ProcessEvent: event to read EventID " << Feu.EventID
+              << " Time " << Feu.TimeStamp << " isample " << Feu.isample << RESTendl;
 
         if (badreadfg) {
-            warning
+            RESTWarning
                 << "TRestRawFEUDreamToSignalProcess::ProcessEvent: Error in reading feu header (bad file or "
                    "end of file), trying to go to the next file"
-                << endl;
+                << RESTendl;
             if (GoToNextFile()) {
                 badreadfg = ReadFeuHeaders(Feu);  // reading event from the next file
-                debug << "TRestRawFEUDreamToSignalProcess::ProcessEvent: header read, badreadfg " << badreadfg
-                      << endl;
-                debug << "TRestRawFEUDreamToSignalProcess::ProcessEvent: event to read EventID "
-                      << Feu.EventID << " Time " << Feu.TimeStamp << " isample " << Feu.isample << endl;
+                RESTDebug << "TRestRawFEUDreamToSignalProcess::ProcessEvent: header read, badreadfg " << badreadfg
+                      << RESTendl;
+                RESTDebug << "TRestRawFEUDreamToSignalProcess::ProcessEvent: event to read EventID "
+                      << Feu.EventID << " Time " << Feu.TimeStamp << " isample " << Feu.isample << RESTendl;
             } else {
                 return nullptr;
             }
@@ -141,10 +141,10 @@ TRestEvent* TRestRawFEUDreamToSignalProcess::ProcessEvent(TRestEvent* inputEvent
 
         // Read event
         badreadfg = ReadEvent(Feu);
-        debug << "TRestRawFEUDreamToSignalProcess::ProcessEvent: event read, badreadfg " << badreadfg << endl;
+        RESTDebug << "TRestRawFEUDreamToSignalProcess::ProcessEvent: event read, badreadfg " << badreadfg << RESTendl;
         if (badreadfg) {
-            ferr << "TRestRawFEUDreamToSignalProcess::ProcessEvent: Error in event reading at event "
-                 << Nevent << endl;
+            RESTFerr << "TRestRawFEUDreamToSignalProcess::ProcessEvent: Error in event reading at event "
+                 << Nevent << RESTendl;
             break;
         }
 
@@ -155,13 +155,13 @@ TRestEvent* TRestRawFEUDreamToSignalProcess::ProcessEvent(TRestEvent* inputEvent
             cout << "TRestRawFEUDreamToSignalProcess::ProcessEvent: " << Nevent
                  << " events processed in file, and " << Nbadevent << " bad events skipped " << endl;
 
-        if (GetVerboseLevel() >= REST_Info) {
-            info << "-- TRestRawFEUDreamToSignalProcess::ProcessEvent ---" << endl;
-            info << "Event ID : " << fSignalEvent->GetID() << endl;
-            info << "Time stamp : " << fSignalEvent->GetTimeStamp() << endl;
-            info << "Number of Signals : " << fSignalEvent->GetNumberOfSignals() << endl;
-            info << "Number of Samples : " << (Feu.isample + 1) << endl;
-            info << "-------------------------------------------------" << endl;
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Info) {
+            RESTInfo << "-- TRestRawFEUDreamToSignalProcess::ProcessEvent ---" << RESTendl;
+            RESTInfo << "Event ID : " << fSignalEvent->GetID() << RESTendl;
+            RESTInfo << "Time stamp : " << fSignalEvent->GetTimeStamp() << RESTendl;
+            RESTInfo << "Number of Signals : " << fSignalEvent->GetNumberOfSignals() << RESTendl;
+            RESTInfo << "Number of Samples : " << (Feu.isample + 1) << RESTendl;
+            RESTInfo << "-------------------------------------------------" << RESTendl;
         }
 
         Feu.isample = -1;
@@ -170,13 +170,13 @@ TRestEvent* TRestRawFEUDreamToSignalProcess::ProcessEvent(TRestEvent* inputEvent
         bad_event = false;
 
         if (fSignalEvent->GetNumberOfSignals() == 0) {
-            ferr << "TRestRawFEUDreamToSignalProcess::ProcessEvent: no signal in event" << endl;
+            RESTFerr << "TRestRawFEUDreamToSignalProcess::ProcessEvent: no signal in event" << RESTendl;
             return nullptr;
         }
 
-        debug << "TRestRawFEUDreamToSignalProcess::ProcessEvent: returning signal event fSignalEvent "
-              << fSignalEvent << endl;
-        if (GetVerboseLevel() > REST_Debug) fSignalEvent->PrintEvent();
+        RESTDebug << "TRestRawFEUDreamToSignalProcess::ProcessEvent: returning signal event fSignalEvent "
+              << fSignalEvent << RESTendl;
+        if (GetVerboseLevel() > TRestStringOutput::REST_Verbose_Level::REST_Debug) fSignalEvent->PrintEvent();
         return fSignalEvent;
     }
 
@@ -189,30 +189,30 @@ bool TRestRawFEUDreamToSignalProcess::ReadEvent(FeuReadOut& Feu) {
 
     while (!Feu.event_completed) {
         badreadfg = ReadFeuHeaders(Feu);  // read feu header if not done
-        debug << "TRestRawFEUDreamToSignalProcess::ReadEvent: header read, badreadfg " << badreadfg << endl;
+        RESTDebug << "TRestRawFEUDreamToSignalProcess::ReadEvent: header read, badreadfg " << badreadfg << RESTendl;
         if (badreadfg) {
-            warning << "TRestRawFEUDreamToSignalProcess::ReadEvent: error in reading FEU headers "
-                    << endl;  // failed
+            RESTWarning << "TRestRawFEUDreamToSignalProcess::ReadEvent: error in reading FEU headers "
+                    << RESTendl;  // failed
             return true;
         }
 
         badreadfg = ReadDreamData(Feu);  // read dream data
-        debug << "TRestRawFEUDreamToSignalProcess::ReadEvent: data read, badreadfg " << badreadfg << endl;
+        RESTDebug << "TRestRawFEUDreamToSignalProcess::ReadEvent: data read, badreadfg " << badreadfg << RESTendl;
         if (badreadfg) {
-            ferr << "TRestRawFEUDreamToSignalProcess::ReadEvent: error in reading Dream data " << endl;
+            RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadEvent: error in reading Dream data " << RESTendl;
             return true;
         }
 
         badreadfg = ReadFeuTrailer(Feu);  // read feu trailer
-        debug << "TRestRawFEUDreamToSignalProcess::ReadEvent: trailer read, badreadfg " << badreadfg << endl;
+        RESTDebug << "TRestRawFEUDreamToSignalProcess::ReadEvent: trailer read, badreadfg " << badreadfg << RESTendl;
         if (badreadfg) {
-            ferr << "TRestRawFEUDreamToSignalProcess::ReadEvent: error in reading FEU trailer" << endl;
+            RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadEvent: error in reading FEU trailer" << RESTendl;
             return true;
         }
 
     }  // end loop
-    info << "TRestRawFEUDreamToSignalProcess::ReadEvent: Event ID " << Feu.EventID
-         << " processed successfully, Time " << Feu.TimeStamp << " isample  " << Feu.isample << endl;
+    RESTInfo << "TRestRawFEUDreamToSignalProcess::ReadEvent: Event ID " << Feu.EventID
+         << " processed successfully, Time " << Feu.TimeStamp << " isample  " << Feu.isample << RESTendl;
 
     return false;
 }
@@ -226,9 +226,9 @@ bool TRestRawFEUDreamToSignalProcess::ReadFeuHeaders(FeuReadOut& Feu) {
         totalBytesReaded += sizeof(Feu.current_data);
         if (nbytes == 0) {
             //       perror("TRestRawFEUDreamToSignalProcess::ReadFeuHeaders: Error in reading FeuHeaders !");
-            warning << "TRestRawFEUDreamToSignalProcess::ReadFeuHeaders: Problem in reading raw file, ferror "
+            RESTWarning << "TRestRawFEUDreamToSignalProcess::ReadFeuHeaders: Problem in reading raw file, ferror "
                     << ferror(fInputBinFile) << " feof " << feof(fInputBinFile) << " fInputBinFile "
-                    << fInputBinFile << endl;
+                    << fInputBinFile << RESTendl;
             //      fclose(fInputBinFile);
             return true;  // failed
         }
@@ -242,18 +242,18 @@ bool TRestRawFEUDreamToSignalProcess::ReadFeuHeaders(FeuReadOut& Feu) {
             if (Feu.FeuHeaderLine == 0) {
                 Feu.zs_mode = Feu.current_data.get_zs_mode();
                 Feu.Id = Feu.current_data.get_Feu_ID();
-                debug << "ReadFeuHeaders: header FeuHeaderLine " << Feu.FeuHeaderLine << " ZS mode "
-                      << Feu.zs_mode << " Id " << Feu.Id << endl;
+                RESTDebug << "ReadFeuHeaders: header FeuHeaderLine " << Feu.FeuHeaderLine << " ZS mode "
+                      << Feu.zs_mode << " Id " << Feu.Id << RESTendl;
 
             } else if (Feu.FeuHeaderLine == 1) {
                 Feu.EventID = Feu.current_data.get_data();
-                debug << "ReadFeuHeaders: header FeuHeaderLine " << Feu.FeuHeaderLine << " EventID "
-                      << Feu.EventID << endl;
+                RESTDebug << "ReadFeuHeaders: header FeuHeaderLine " << Feu.FeuHeaderLine << " EventID "
+                      << Feu.EventID << RESTendl;
 
             } else if (Feu.FeuHeaderLine == 2) {
                 Feu.TimeStamp = Feu.current_data.get_data();
-                debug << "ReadFeuHeaders: header FeuHeaderLine " << Feu.FeuHeaderLine << " TimeStamp "
-                      << Feu.TimeStamp << endl;
+                RESTDebug << "ReadFeuHeaders: header FeuHeaderLine " << Feu.FeuHeaderLine << " TimeStamp "
+                      << Feu.TimeStamp << RESTendl;
 
             } else if (Feu.FeuHeaderLine == 3) {
                 Feu.FineTimeStamp = Feu.current_data.get_finetstp();
@@ -266,47 +266,47 @@ bool TRestRawFEUDreamToSignalProcess::ReadFeuHeaders(FeuReadOut& Feu) {
                             fMinPoints - 2) {  // finishing the current event and starting the next one
                                                // fprintf(stderr, "Event ID %d, processed \n", Feu.EventID-1);
                     } else {
-                        ferr
+                        RESTFerr
                             << "TRestRawFEUDreamToSignalProcess::ReadFeuHeaders: non continuous sample index "
                                "number, isample = "
-                            << Feu.isample << " prev_isample = " << Feu.isample_prev << endl;
+                            << Feu.isample << " prev_isample = " << Feu.isample_prev << RESTendl;
                         bad_event = true;
                     }
                 }
-                debug << "ReadFeuHeaders: header FeuHeaderLine " << Feu.FeuHeaderLine << " FineTimeStamp "
-                      << Feu.FineTimeStamp << " isample " << Feu.isample << endl;
+                RESTDebug << "ReadFeuHeaders: header FeuHeaderLine " << Feu.FeuHeaderLine << " FineTimeStamp "
+                      << Feu.FineTimeStamp << " isample " << Feu.isample << RESTendl;
 
                 // Reading optionals
             } else if (Feu.FeuHeaderLine == 4) {
                 Feu.EventID_Op = Feu.current_data.get_data();
                 Feu.EventID += (1 << 12) * Feu.EventID_Op;
-                debug << "ReadFeuHeaders: header FeuHeaderLine " << Feu.FeuHeaderLine << " EventID_Op "
-                      << Feu.EventID_Op << endl;
+                RESTDebug << "ReadFeuHeaders: header FeuHeaderLine " << Feu.FeuHeaderLine << " EventID_Op "
+                      << Feu.EventID_Op << RESTendl;
 
             } else if (Feu.FeuHeaderLine == 5) {
                 Feu.TimeStamp_Op1 = Feu.current_data.get_data();
-                debug << "ReadFeuHeaders: header FeuHeaderLine " << Feu.FeuHeaderLine << " TimeStamp_Op1 "
-                      << Feu.TimeStamp_Op1 << endl;
+                RESTDebug << "ReadFeuHeaders: header FeuHeaderLine " << Feu.FeuHeaderLine << " TimeStamp_Op1 "
+                      << Feu.TimeStamp_Op1 << RESTendl;
 
             } else if (Feu.FeuHeaderLine == 6) {
                 Feu.TimeStamp_Op2 = Feu.current_data.get_data();
-                debug << "ReadFeuHeaders: header FeuHeaderLine " << Feu.FeuHeaderLine << " TimeStamp_Op2 "
-                      << Feu.TimeStamp_Op2 << endl;
+                RESTDebug << "ReadFeuHeaders: header FeuHeaderLine " << Feu.FeuHeaderLine << " TimeStamp_Op2 "
+                      << Feu.TimeStamp_Op2 << RESTendl;
 
             } else if (Feu.FeuHeaderLine == 7) {
                 Feu.TimeStamp_Op3 = Feu.current_data.get_TimeStamp_Op();
                 Feu.TimeStamp += ((long long)1 << 36) * Feu.TimeStamp_Op3 + (1 << 24) * Feu.TimeStamp_Op2 +
                                  (1 << 12) * Feu.TimeStamp_Op1;
-                debug << "ReadFeuHeaders: header FeuHeaderLine " << Feu.FeuHeaderLine << " TimeStamp_Op3 "
-                      << Feu.TimeStamp_Op3 << " TimeStamp " << Feu.TimeStamp << endl;
+                RESTDebug << "ReadFeuHeaders: header FeuHeaderLine " << Feu.FeuHeaderLine << " TimeStamp_Op3 "
+                      << Feu.TimeStamp_Op3 << " TimeStamp " << Feu.TimeStamp << RESTendl;
             }
 
             Feu.data_to_treat = false;
             Feu.FeuHeaderLine++;
 
         } else if (Feu.FeuHeaderLine > 8 && Feu.current_data.is_Feu_header()) {
-            ferr << "TRestRawFEUDreamToSignalProcess::ReadFeuHeaders: too long Feu header part  "
-                 << Feu.FeuHeaderLine << endl;
+            RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadFeuHeaders: too long Feu header part  "
+                 << Feu.FeuHeaderLine << RESTendl;
             bad_event = true;
         } else if (Feu.FeuHeaderLine > 3 && !Feu.current_data.is_Feu_header())
             break;  // header finished
@@ -330,9 +330,9 @@ bool TRestRawFEUDreamToSignalProcess::ReadDreamData(FeuReadOut& Feu) {
     int ichannel = 0;
 
     if (!Feu.FeuHeaderLoaded) {  // already loaded
-        ferr
+        RESTFerr
             << "TRestRawFEUDreamToSignalProcess::ReadDreamData: error in ReadDreamData, Feu header not loaded"
-            << endl;
+            << RESTendl;
         return true;
     }
 
@@ -341,10 +341,10 @@ bool TRestRawFEUDreamToSignalProcess::ReadDreamData(FeuReadOut& Feu) {
         totalBytesReaded += sizeof(Feu.current_data);
         if (nbytes == 0) {
             perror("TRestRawFEUDreamToSignalProcess::ReadDreamData: no Dream data to read in file");
-            ferr << "TRestRawFEUDreamToSignalProcess::ReadDreamData:  problem in reading raw data file, "
+            RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadDreamData:  problem in reading raw data file, "
                     "ferror "
                  << ferror(fInputBinFile) << " feof " << feof(fInputBinFile) << " fInputBinFile "
-                 << fInputBinFile << endl;
+                 << fInputBinFile << RESTendl;
             fclose(fInputBinFile);
             return true;  // failed
         }
@@ -358,18 +358,18 @@ bool TRestRawFEUDreamToSignalProcess::ReadDreamData(FeuReadOut& Feu) {
             if (Feu.DataHeaderLine < 4 && Feu.current_data.is_data_header()) {  // data header treatment
                 if (Feu.DataHeaderLine == 0) {
                     Feu.TriggerID = Feu.current_data.get_data();  // trigger Id MSB
-                    debug << "ReadDreamData: header DataHeaderLine " << Feu.DataHeaderLine
-                          << " TriggerID MSB " << Feu.TriggerID << endl;
+                    RESTDebug << "ReadDreamData: header DataHeaderLine " << Feu.DataHeaderLine
+                          << " TriggerID MSB " << Feu.TriggerID << RESTendl;
                 } else if (Feu.DataHeaderLine == 1) {
                     Feu.TriggerID_ISB = Feu.current_data.get_data();
-                    debug << "ReadDreamData: header DataHeaderLine " << Feu.DataHeaderLine
-                          << " TriggerID_ISB " << Feu.TriggerID_ISB << endl;
+                    RESTDebug << "ReadDreamData: header DataHeaderLine " << Feu.DataHeaderLine
+                          << " TriggerID_ISB " << Feu.TriggerID_ISB << RESTendl;
                 } else if (Feu.DataHeaderLine == 2) {
                     Feu.TriggerID_LSB = Feu.current_data.get_data();
                     Feu.TriggerID *= (1 << 24);
                     Feu.TriggerID += Feu.TriggerID_LSB + (1 << 12) * Feu.TriggerID_ISB;
-                    debug << "ReadDreamData: header DataHeaderLine " << Feu.DataHeaderLine
-                          << " TriggerID_LSB " << Feu.TriggerID_LSB << " TriggerID " << Feu.TriggerID << endl;
+                    RESTDebug << "ReadDreamData: header DataHeaderLine " << Feu.DataHeaderLine
+                          << " TriggerID_LSB " << Feu.TriggerID_LSB << " TriggerID " << Feu.TriggerID << RESTendl;
                 } else if (Feu.DataHeaderLine == 3) {
                     Feu.asicN = Feu.current_data.get_dream_ID();  // Dream_ID
                     ichannel = 0;  // reset counting of channels for the current Dream chip
@@ -377,26 +377,26 @@ bool TRestRawFEUDreamToSignalProcess::ReadDreamData(FeuReadOut& Feu) {
                     Feu.DataTrailerLine = 0;
                     // fprintf(stderr, " asic N  %d \n", Feu.asicN);
                     got_raw_data_header = true;
-                    debug << "ReadDreamData: header DataHeaderLine " << Feu.DataHeaderLine << " asicN "
-                          << Feu.asicN << endl;
+                    RESTDebug << "ReadDreamData: header DataHeaderLine " << Feu.DataHeaderLine << " asicN "
+                          << Feu.asicN << RESTendl;
                 }
                 Feu.DataHeaderLine++;
                 Feu.data_to_treat = false;
 
             } else if (Feu.DataHeaderLine > 3 && Feu.current_data.is_data_header()) {
                 bad_event = true;
-                ferr << "TRestRawFEUDreamToSignalProcess::ReadDreamData: too many data header lines, "
+                RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadDreamData: too many data header lines, "
                         "DataHeaderLine "
-                     << Feu.DataHeaderLine << endl;
+                     << Feu.DataHeaderLine << RESTendl;
                 return true;
 
             } else if (Feu.current_data.is_data() &&
                        !Feu.zs_mode) {  // data lines treatment, non-zero suppression mode
                 if (!got_raw_data_header) {
                     bad_event = true;
-                    ferr << "TRestRawFEUDreamToSignalProcess::ReadDreamData: data lines without header in "
+                    RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadDreamData: data lines without header in "
                             "non-ZS mode "
-                         << endl;
+                         << RESTendl;
                 }
                 Feu.channelN = ichannel;
                 if (!bad_event && Feu.channelN > -1 && Feu.channelN < NstripMax &&
@@ -415,12 +415,12 @@ bool TRestRawFEUDreamToSignalProcess::ReadDreamData(FeuReadOut& Feu) {
                         fSignalEvent->AddChargeToSignal(Feu.physChannel, Feu.isample,
                                                         Feu.current_data.get_data());
                     } else
-                        ferr << "TRestRawFEUDreamToSignalProcess::ReadDreamData: too large physical Channel "
+                        RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadDreamData: too large physical Channel "
                                 "in "
                                 "non-ZS mode , Feu.physChannel=  "
-                             << Feu.physChannel << " > MaxPhysChannel " << MaxPhysChannel << endl;
-                    extreme << "ReadDreamData: nonZS physChannel " << Feu.physChannel << " get_data "
-                            << Feu.current_data.get_data() << endl;
+                             << Feu.physChannel << " > MaxPhysChannel " << MaxPhysChannel << RESTendl;
+                    RESTExtreme << "ReadDreamData: nonZS physChannel " << Feu.physChannel << " get_data "
+                            << Feu.current_data.get_data() << RESTendl;
                 }
                 ichannel++;
                 Feu.data_to_treat = false;
@@ -428,9 +428,9 @@ bool TRestRawFEUDreamToSignalProcess::ReadDreamData(FeuReadOut& Feu) {
             } else if (Feu.current_data.is_data_zs() && Feu.zs_mode) {  // zero-suppression mode
                 if (got_raw_data_header) {
                     bad_event = true;
-                    ferr << "TRestRawFEUDreamToSignalProcess::ReadDreamData: data lines with header in ZS "
+                    RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadDreamData: data lines with header in ZS "
                             "mode "
-                         << endl;
+                         << RESTendl;
                 }
                 if (!got_channel_id && Feu.current_data.is_channel_ID()) {  // get channelID and dreamID
                     ichannel = Feu.current_data.get_channel_ID();
@@ -439,21 +439,21 @@ bool TRestRawFEUDreamToSignalProcess::ReadDreamData(FeuReadOut& Feu) {
                     Feu.physChannel = Feu.asicN * NstripMax + Feu.channelN;  // channel's number on the DREAM
                     got_channel_id = true;
                     if (Feu.channelN < 0 || Feu.channelN >= NstripMax) {
-                        ferr << "TRestRawFEUDreamToSignalProcess::ReadDreamData: too large channel number in "
+                        RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadDreamData: too large channel number in "
                                 "ZS "
                                 "mode , Feu.channelN=  "
-                             << Feu.channelN << " > MaxPhysChannel " << MaxPhysChannel << endl;
+                             << Feu.channelN << " > MaxPhysChannel " << MaxPhysChannel << RESTendl;
                         bad_event = true;
                     }
-                    extreme << "ReadDreamData: ZS header physChannel " << Feu.physChannel << " asicN "
-                            << Feu.asicN << " ichannel " << ichannel << endl;
+                    RESTExtreme << "ReadDreamData: ZS header physChannel " << Feu.physChannel << " asicN "
+                            << Feu.asicN << " ichannel " << ichannel << RESTendl;
                 } else {  // get channel data
                     got_channel_id = false;
                     if (!bad_event && Feu.channelN > -1 && Feu.channelN < NstripMax &&
                         Feu.isample < fMinPoints) {
                         Feu.channel_data = Feu.current_data.get_data();
                     }
-                    extreme << "ReadDreamData: ZS data get_data " << Feu.current_data.get_data() << endl;
+                    RESTExtreme << "ReadDreamData: ZS data get_data " << Feu.current_data.get_data() << RESTendl;
                 }
 
                 if (Feu.physChannel < MaxPhysChannel) {
@@ -466,51 +466,51 @@ bool TRestRawFEUDreamToSignalProcess::ReadDreamData(FeuReadOut& Feu) {
                     }
                     fSignalEvent->AddChargeToSignal(Feu.physChannel, Feu.isample, Feu.channel_data);
                 } else
-                    ferr
+                    RESTFerr
                         << "TRestRawFEUDreamToSignalProcess::ReadDreamData: too large physical Channel in ZS "
                            "mode , Feu.physChannel=  "
-                        << Feu.physChannel << " > MaxPhysChannel " << MaxPhysChannel << endl;
+                        << Feu.physChannel << " > MaxPhysChannel " << MaxPhysChannel << RESTendl;
                 Feu.data_to_treat = false;
 
             } else if (Feu.current_data.is_data_trailer()) {  // data trailer treatment
 
                 if (ichannel != NstripMax && !Feu.zs_mode) {
                     bad_event = true;
-                    ferr << "TRestRawFEUDreamToSignalProcess::ReadDreamData: trailer with missing channel "
+                    RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadDreamData: trailer with missing channel "
                             "numbers in non-ZS mode, ichannel "
-                         << ichannel << endl;
+                         << ichannel << RESTendl;
                     return true;
                 }
                 if (got_channel_id && Feu.zs_mode) {
                     bad_event = true;
-                    ferr << "TRestRawFEUDreamToSignalProcess::ReadDreamData: trailer with channel Id without "
+                    RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadDreamData: trailer with channel Id without "
                             "channel data in ZS data, got_channel_id true"
-                         << endl;
+                         << RESTendl;
                     return true;
                 }
 
                 if (Feu.DataTrailerLine == 0) {  // CMN
                     Feu.CMN = Feu.current_data.get_data();
-                    debug << "ReadDreamData: trailer DataTrailerLine " << Feu.DataTrailerLine << " CMN "
-                          << Feu.CMN << endl;
+                    RESTDebug << "ReadDreamData: trailer DataTrailerLine " << Feu.DataTrailerLine << " CMN "
+                          << Feu.CMN << RESTendl;
                 } else if (Feu.DataTrailerLine == 1) {
                     Feu.CMN_rest = Feu.current_data.get_data();
-                    debug << "ReadDreamData: trailer DataTrailerLine " << Feu.DataTrailerLine << " CMN_rest "
-                          << Feu.CMN_rest << endl;
+                    RESTDebug << "ReadDreamData: trailer DataTrailerLine " << Feu.DataTrailerLine << " CMN_rest "
+                          << Feu.CMN_rest << RESTendl;
                 } else if (Feu.DataTrailerLine == 2) {  // Cell_ID
                     Feu.Cell_ID_MSB = Feu.current_data.get_data();
-                    debug << "ReadDreamData: trailer DataTrailerLine " << Feu.DataTrailerLine
-                          << " Cell_ID_MSB " << Feu.Cell_ID_MSB << endl;
+                    RESTDebug << "ReadDreamData: trailer DataTrailerLine " << Feu.DataTrailerLine
+                          << " Cell_ID_MSB " << Feu.Cell_ID_MSB << RESTendl;
                 } else if (Feu.DataTrailerLine == 3) {
                     Feu.Cell_ID_ISB = Feu.current_data.get_data();
-                    debug << "ReadDreamData: trailer DataTrailerLine " << Feu.DataTrailerLine
-                          << " Cell_ID_ISB " << Feu.Cell_ID_ISB << endl;
+                    RESTDebug << "ReadDreamData: trailer DataTrailerLine " << Feu.DataTrailerLine
+                          << " Cell_ID_ISB " << Feu.Cell_ID_ISB << RESTendl;
                 } else if (Feu.DataTrailerLine == 4) {
                     Feu.Cell_ID_LSB = Feu.current_data.get_data();
                     Feu.Cell_ID = Feu.Cell_ID_LSB + (1 << 12) * Feu.Cell_ID_ISB +
                                   ((long long)1 << 24) * Feu.Cell_ID_MSB;
-                    debug << "ReadDreamData: trailer DataTrailerLine " << Feu.DataTrailerLine
-                          << " Cell_ID_LSB " << Feu.Cell_ID_LSB << " Cell_ID " << Feu.Cell_ID << endl;
+                    RESTDebug << "ReadDreamData: trailer DataTrailerLine " << Feu.DataTrailerLine
+                          << " Cell_ID_LSB " << Feu.Cell_ID_LSB << " Cell_ID " << Feu.Cell_ID << RESTendl;
                     Feu.DataHeaderLine = 0;
                     got_raw_data_header = false;
                     Feu.channelN = 0;
@@ -520,9 +520,9 @@ bool TRestRawFEUDreamToSignalProcess::ReadDreamData(FeuReadOut& Feu) {
 
             } else if (Feu.DataTrailerLine > 4 && Feu.current_data.is_data_trailer()) {
                 bad_event = true;
-                ferr << "TRestRawFEUDreamToSignalProcess::ReadDreamData: too many data trailer lines, "
+                RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadDreamData: too many data trailer lines, "
                         "DataTrailerLine "
-                     << Feu.DataTrailerLine << endl;
+                     << Feu.DataTrailerLine << RESTendl;
                 return true;
 
             } else if (Feu.current_data.is_final_trailer())
@@ -544,14 +544,14 @@ bool TRestRawFEUDreamToSignalProcess::ReadFeuTrailer(FeuReadOut& Feu) {
         totalBytesReaded += sizeof(Feu.current_data);
         if (nbytes == 0) {
             perror("TRestRawFEUDreamToSignalProcess::ReadFeuTrailer: can't read new data from file");
-            ferr << "TRestRawFEUDreamToSignalProcess::ReadFeuTrailer: can't read new data from file, ferror "
+            RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadFeuTrailer: can't read new data from file, ferror "
                  << ferror(fInputBinFile) << " feof " << feof(fInputBinFile) << " fInputBinFile "
-                 << fInputBinFile << endl;
+                 << fInputBinFile << RESTendl;
             fclose(fInputBinFile);
             return true;  // failed
         }
-        debug << "TRestRawFEUDreamToSignalProcess::ReadFeuTrailer: Reading FeuTrailer ok, nbytes " << nbytes
-              << endl;
+        RESTDebug << "TRestRawFEUDreamToSignalProcess::ReadFeuTrailer: Reading FeuTrailer ok, nbytes " << nbytes
+              << RESTendl;
         Feu.current_data.ntohs_();
         Feu.data_to_treat = true;
     }
@@ -560,18 +560,18 @@ bool TRestRawFEUDreamToSignalProcess::ReadFeuTrailer(FeuReadOut& Feu) {
         if (Feu.current_data.is_final_trailer()) {
             if (Feu.channelN != 0) {
                 bad_event = true;
-                ferr << "TRestRawFEUDreamToSignalProcess::ReadFeuTrailer: channel number not NULL in "
+                RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadFeuTrailer: channel number not NULL in "
                         "trailer, "
                         "Feu.channelN "
-                     << Feu.channelN << endl;
+                     << Feu.channelN << RESTendl;
                 return true;
             }
             if (Feu.current_data.is_end_of_event()) {
                 if (Feu.isample != (fMinPoints - 1)) {
-                    warning
+                    RESTWarning
                         << "TRestRawFEUDreamToSignalProcess::ReadFeuTrailer: not all samples read at end of "
                            "event, isample "
-                        << Feu.isample << " MinPoints " << fMinPoints << endl;
+                        << Feu.isample << " MinPoints " << fMinPoints << RESTendl;
                 }
                 //         Feu.isample=-1; Feu.isample_prev=-2;
                 Feu.event_completed = true;

--- a/src/TRestRawFEUDreamToSignalProcess.cxx
+++ b/src/TRestRawFEUDreamToSignalProcess.cxx
@@ -143,7 +143,7 @@ TRestEvent* TRestRawFEUDreamToSignalProcess::ProcessEvent(TRestEvent* inputEvent
         badreadfg = ReadEvent(Feu);
         RESTDebug << "TRestRawFEUDreamToSignalProcess::ProcessEvent: event read, badreadfg " << badreadfg << RESTendl;
         if (badreadfg) {
-            RESTFerr << "TRestRawFEUDreamToSignalProcess::ProcessEvent: Error in event reading at event "
+            RESTError << "TRestRawFEUDreamToSignalProcess::ProcessEvent: Error in event reading at event "
                  << Nevent << RESTendl;
             break;
         }
@@ -170,7 +170,7 @@ TRestEvent* TRestRawFEUDreamToSignalProcess::ProcessEvent(TRestEvent* inputEvent
         bad_event = false;
 
         if (fSignalEvent->GetNumberOfSignals() == 0) {
-            RESTFerr << "TRestRawFEUDreamToSignalProcess::ProcessEvent: no signal in event" << RESTendl;
+            RESTError << "TRestRawFEUDreamToSignalProcess::ProcessEvent: no signal in event" << RESTendl;
             return nullptr;
         }
 
@@ -199,14 +199,14 @@ bool TRestRawFEUDreamToSignalProcess::ReadEvent(FeuReadOut& Feu) {
         badreadfg = ReadDreamData(Feu);  // read dream data
         RESTDebug << "TRestRawFEUDreamToSignalProcess::ReadEvent: data read, badreadfg " << badreadfg << RESTendl;
         if (badreadfg) {
-            RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadEvent: error in reading Dream data " << RESTendl;
+            RESTError << "TRestRawFEUDreamToSignalProcess::ReadEvent: error in reading Dream data " << RESTendl;
             return true;
         }
 
         badreadfg = ReadFeuTrailer(Feu);  // read feu trailer
         RESTDebug << "TRestRawFEUDreamToSignalProcess::ReadEvent: trailer read, badreadfg " << badreadfg << RESTendl;
         if (badreadfg) {
-            RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadEvent: error in reading FEU trailer" << RESTendl;
+            RESTError << "TRestRawFEUDreamToSignalProcess::ReadEvent: error in reading FEU trailer" << RESTendl;
             return true;
         }
 
@@ -266,7 +266,7 @@ bool TRestRawFEUDreamToSignalProcess::ReadFeuHeaders(FeuReadOut& Feu) {
                             fMinPoints - 2) {  // finishing the current event and starting the next one
                                                // fprintf(stderr, "Event ID %d, processed \n", Feu.EventID-1);
                     } else {
-                        RESTFerr
+                        RESTError
                             << "TRestRawFEUDreamToSignalProcess::ReadFeuHeaders: non continuous sample index "
                                "number, isample = "
                             << Feu.isample << " prev_isample = " << Feu.isample_prev << RESTendl;
@@ -305,7 +305,7 @@ bool TRestRawFEUDreamToSignalProcess::ReadFeuHeaders(FeuReadOut& Feu) {
             Feu.FeuHeaderLine++;
 
         } else if (Feu.FeuHeaderLine > 8 && Feu.current_data.is_Feu_header()) {
-            RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadFeuHeaders: too long Feu header part  "
+            RESTError << "TRestRawFEUDreamToSignalProcess::ReadFeuHeaders: too long Feu header part  "
                  << Feu.FeuHeaderLine << RESTendl;
             bad_event = true;
         } else if (Feu.FeuHeaderLine > 3 && !Feu.current_data.is_Feu_header())
@@ -330,7 +330,7 @@ bool TRestRawFEUDreamToSignalProcess::ReadDreamData(FeuReadOut& Feu) {
     int ichannel = 0;
 
     if (!Feu.FeuHeaderLoaded) {  // already loaded
-        RESTFerr
+        RESTError
             << "TRestRawFEUDreamToSignalProcess::ReadDreamData: error in ReadDreamData, Feu header not loaded"
             << RESTendl;
         return true;
@@ -341,7 +341,7 @@ bool TRestRawFEUDreamToSignalProcess::ReadDreamData(FeuReadOut& Feu) {
         totalBytesReaded += sizeof(Feu.current_data);
         if (nbytes == 0) {
             perror("TRestRawFEUDreamToSignalProcess::ReadDreamData: no Dream data to read in file");
-            RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadDreamData:  problem in reading raw data file, "
+            RESTError << "TRestRawFEUDreamToSignalProcess::ReadDreamData:  problem in reading raw data file, "
                     "ferror "
                  << ferror(fInputBinFile) << " feof " << feof(fInputBinFile) << " fInputBinFile "
                  << fInputBinFile << RESTendl;
@@ -385,7 +385,7 @@ bool TRestRawFEUDreamToSignalProcess::ReadDreamData(FeuReadOut& Feu) {
 
             } else if (Feu.DataHeaderLine > 3 && Feu.current_data.is_data_header()) {
                 bad_event = true;
-                RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadDreamData: too many data header lines, "
+                RESTError << "TRestRawFEUDreamToSignalProcess::ReadDreamData: too many data header lines, "
                         "DataHeaderLine "
                      << Feu.DataHeaderLine << RESTendl;
                 return true;
@@ -394,7 +394,7 @@ bool TRestRawFEUDreamToSignalProcess::ReadDreamData(FeuReadOut& Feu) {
                        !Feu.zs_mode) {  // data lines treatment, non-zero suppression mode
                 if (!got_raw_data_header) {
                     bad_event = true;
-                    RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadDreamData: data lines without header in "
+                    RESTError << "TRestRawFEUDreamToSignalProcess::ReadDreamData: data lines without header in "
                             "non-ZS mode "
                          << RESTendl;
                 }
@@ -415,7 +415,7 @@ bool TRestRawFEUDreamToSignalProcess::ReadDreamData(FeuReadOut& Feu) {
                         fSignalEvent->AddChargeToSignal(Feu.physChannel, Feu.isample,
                                                         Feu.current_data.get_data());
                     } else
-                        RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadDreamData: too large physical Channel "
+                        RESTError << "TRestRawFEUDreamToSignalProcess::ReadDreamData: too large physical Channel "
                                 "in "
                                 "non-ZS mode , Feu.physChannel=  "
                              << Feu.physChannel << " > MaxPhysChannel " << MaxPhysChannel << RESTendl;
@@ -428,7 +428,7 @@ bool TRestRawFEUDreamToSignalProcess::ReadDreamData(FeuReadOut& Feu) {
             } else if (Feu.current_data.is_data_zs() && Feu.zs_mode) {  // zero-suppression mode
                 if (got_raw_data_header) {
                     bad_event = true;
-                    RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadDreamData: data lines with header in ZS "
+                    RESTError << "TRestRawFEUDreamToSignalProcess::ReadDreamData: data lines with header in ZS "
                             "mode "
                          << RESTendl;
                 }
@@ -439,7 +439,7 @@ bool TRestRawFEUDreamToSignalProcess::ReadDreamData(FeuReadOut& Feu) {
                     Feu.physChannel = Feu.asicN * NstripMax + Feu.channelN;  // channel's number on the DREAM
                     got_channel_id = true;
                     if (Feu.channelN < 0 || Feu.channelN >= NstripMax) {
-                        RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadDreamData: too large channel number in "
+                        RESTError << "TRestRawFEUDreamToSignalProcess::ReadDreamData: too large channel number in "
                                 "ZS "
                                 "mode , Feu.channelN=  "
                              << Feu.channelN << " > MaxPhysChannel " << MaxPhysChannel << RESTendl;
@@ -466,7 +466,7 @@ bool TRestRawFEUDreamToSignalProcess::ReadDreamData(FeuReadOut& Feu) {
                     }
                     fSignalEvent->AddChargeToSignal(Feu.physChannel, Feu.isample, Feu.channel_data);
                 } else
-                    RESTFerr
+                    RESTError
                         << "TRestRawFEUDreamToSignalProcess::ReadDreamData: too large physical Channel in ZS "
                            "mode , Feu.physChannel=  "
                         << Feu.physChannel << " > MaxPhysChannel " << MaxPhysChannel << RESTendl;
@@ -476,14 +476,14 @@ bool TRestRawFEUDreamToSignalProcess::ReadDreamData(FeuReadOut& Feu) {
 
                 if (ichannel != NstripMax && !Feu.zs_mode) {
                     bad_event = true;
-                    RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadDreamData: trailer with missing channel "
+                    RESTError << "TRestRawFEUDreamToSignalProcess::ReadDreamData: trailer with missing channel "
                             "numbers in non-ZS mode, ichannel "
                          << ichannel << RESTendl;
                     return true;
                 }
                 if (got_channel_id && Feu.zs_mode) {
                     bad_event = true;
-                    RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadDreamData: trailer with channel Id without "
+                    RESTError << "TRestRawFEUDreamToSignalProcess::ReadDreamData: trailer with channel Id without "
                             "channel data in ZS data, got_channel_id true"
                          << RESTendl;
                     return true;
@@ -520,7 +520,7 @@ bool TRestRawFEUDreamToSignalProcess::ReadDreamData(FeuReadOut& Feu) {
 
             } else if (Feu.DataTrailerLine > 4 && Feu.current_data.is_data_trailer()) {
                 bad_event = true;
-                RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadDreamData: too many data trailer lines, "
+                RESTError << "TRestRawFEUDreamToSignalProcess::ReadDreamData: too many data trailer lines, "
                         "DataTrailerLine "
                      << Feu.DataTrailerLine << RESTendl;
                 return true;
@@ -544,7 +544,7 @@ bool TRestRawFEUDreamToSignalProcess::ReadFeuTrailer(FeuReadOut& Feu) {
         totalBytesReaded += sizeof(Feu.current_data);
         if (nbytes == 0) {
             perror("TRestRawFEUDreamToSignalProcess::ReadFeuTrailer: can't read new data from file");
-            RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadFeuTrailer: can't read new data from file, ferror "
+            RESTError << "TRestRawFEUDreamToSignalProcess::ReadFeuTrailer: can't read new data from file, ferror "
                  << ferror(fInputBinFile) << " feof " << feof(fInputBinFile) << " fInputBinFile "
                  << fInputBinFile << RESTendl;
             fclose(fInputBinFile);
@@ -560,7 +560,7 @@ bool TRestRawFEUDreamToSignalProcess::ReadFeuTrailer(FeuReadOut& Feu) {
         if (Feu.current_data.is_final_trailer()) {
             if (Feu.channelN != 0) {
                 bad_event = true;
-                RESTFerr << "TRestRawFEUDreamToSignalProcess::ReadFeuTrailer: channel number not NULL in "
+                RESTError << "TRestRawFEUDreamToSignalProcess::ReadFeuTrailer: channel number not NULL in "
                         "trailer, "
                         "Feu.channelN "
                      << Feu.channelN << RESTendl;

--- a/src/TRestRawMemoryBufferToSignalProcess.cxx
+++ b/src/TRestRawMemoryBufferToSignalProcess.cxx
@@ -244,7 +244,7 @@ void TRestRawMemoryBufferToSignalProcess::InitProcess() {
         exit(1);
     }
 
-    if (GetVerboseLevel() >= REST_Debug) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         printf("Sem id : %d\n", fSemaphoreId);
 
         printf("Data ready : %d\n", fShMem_daqInfo->dataReady);
@@ -259,7 +259,7 @@ void TRestRawMemoryBufferToSignalProcess::InitProcess() {
         printf("Max samples : %d\n", fShMem_daqInfo->maxSamples);
         printf("Buffer size : %d\n", fShMem_daqInfo->bufferSize);
 
-        if (GetVerboseLevel() >= REST_Extreme) GetChar();
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) GetChar();
     }
 
     int N_DATA = fShMem_daqInfo->bufferSize;
@@ -303,7 +303,7 @@ TRestEvent* TRestRawMemoryBufferToSignalProcess::ProcessEvent(TRestEvent* inputE
                 TRestRawSignal sgnl;
                 sgnl.SetSignalID(fShMem_Buffer[s * (maxSamples + 1)]);
 
-                if (GetVerboseLevel() >= REST_Debug)
+                if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
                     cout << "s : " << s << " id : " << sgnl.GetSignalID() << endl;
 
                 for (int n = 0; n < maxSamples; n++) {
@@ -311,7 +311,7 @@ TRestEvent* TRestRawMemoryBufferToSignalProcess::ProcessEvent(TRestEvent* inputE
                 }
                 fOutputRawSignalEvent->AddSignal(sgnl);
 
-                if (GetVerboseLevel() >= REST_Extreme) {
+                if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) {
                     sgnl.Print();
                     GetChar();
                 }
@@ -329,14 +329,14 @@ TRestEvent* TRestRawMemoryBufferToSignalProcess::ProcessEvent(TRestEvent* inputE
             SemaphoreGreen(fSemaphoreId);
             //// END Getting access to shared resources
 
-            if (GetVerboseLevel() >= REST_Info) {
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Info) {
                 cout << "------------------------------------------" << endl;
                 cout << "Event ID : " << fOutputRawSignalEvent->GetID() << endl;
                 cout << "Time stamp : " << fOutputRawSignalEvent->GetTimeStamp() << endl;
                 cout << "Number of Signals : " << fOutputRawSignalEvent->GetNumberOfSignals() << endl;
                 cout << "------------------------------------------" << endl;
 
-                if (GetVerboseLevel() >= REST_Debug) {
+                if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
                     for (Int_t n = 0; n < fOutputRawSignalEvent->GetNumberOfSignals(); n++)
                         cout << "Signal N : " << n
                              << " daq id : " << fOutputRawSignalEvent->GetSignal(n)->GetID() << endl;

--- a/src/TRestRawMultiCoBoAsAdToSignalProcess.cxx
+++ b/src/TRestRawMultiCoBoAsAdToSignalProcess.cxx
@@ -187,7 +187,7 @@ TRestEvent* TRestRawMultiCoBoAsAdToSignalProcess::ProcessEvent(TRestEvent* input
 
     // Int_t nextId = GetLowestEventId();
 
-    if (GetVerboseLevel() >= REST_Debug) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "TRestRawMultiCoBoAsAdToSignalProcess: Generating event with ID: " << fCurrentEvent << endl;
     }
 
@@ -210,7 +210,7 @@ TRestEvent* TRestRawMultiCoBoAsAdToSignalProcess::ProcessEvent(TRestEvent* input
 
                     fSignalEvent->AddSignal(signal);
 
-                    if (GetVerboseLevel() >= REST_Extreme) {
+                    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) {
                         cout << "AgetId, chnId, first value, max value: " << m / 68 << ", " << m % 68 << ", "
                              << signal.GetData(0) << ", " << signal.GetMaxValue() << endl;
                     }
@@ -222,7 +222,7 @@ TRestEvent* TRestRawMultiCoBoAsAdToSignalProcess::ProcessEvent(TRestEvent* input
         it++;
     }
 
-    if (GetVerboseLevel() >= REST_Debug) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "TRestRawMultiCoBoAsAdToSignalProcess: event time is : " << tSt << endl;
         cout << "TRestRawMultiCoBoAsAdToSignalProcess: " << fSignalEvent->GetNumberOfSignals()
              << " signals added" << endl;
@@ -242,8 +242,8 @@ TRestEvent* TRestRawMultiCoBoAsAdToSignalProcess::ProcessEvent(TRestEvent* input
 void TRestRawMultiCoBoAsAdToSignalProcess::EndProcess() {
     for (int i = 0; i < fileerrors.size(); i++) {
         if (fileerrors[i] > 0) {
-            warning << "Found " << fileerrors[i] << " error frame headers in file " << i << endl;
-            warning << "\"" << fInputFileNames[i] << "\"" << endl;
+            RESTWarning << "Found " << fileerrors[i] << " error frame headers in file " << i << RESTendl;
+            RESTWarning << "\"" << fInputFileNames[i] << "\"" << RESTendl;
         }
     }
 
@@ -298,11 +298,11 @@ bool TRestRawMultiCoBoAsAdToSignalProcess::FillBuffer() {
         // b. read the next frame header
         // c. if eventid is the same as current, return to a, otherwise break.
         while (fHeaderFrame[i].eventIdx == fCurrentEvent) {
-            if (GetVerboseLevel() >= REST_Debug) {
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
                 cout << "TRestRawMultiCoBoAsAdToSignalProcess: retrieving frame header in "
                         "file "
                      << i << " (" << fInputFileNames[i] << ")" << endl;
-                if (GetVerboseLevel() >= REST_Extreme) fHeaderFrame[i].Show();
+                if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) fHeaderFrame[i].Show();
             }
 
             // reading data according to the header
@@ -336,14 +336,14 @@ bool TRestRawMultiCoBoAsAdToSignalProcess::FillBuffer() {
             }
             totalBytesReaded += 256;
             if (!ReadFrameHeader(fHeaderFrame[i])) {
-                warning << "Event " << fCurrentEvent << " : error when reading next frame header" << endl;
-                warning << "in file " << i << " \"" << fInputFileNames[i] << "\"" << endl;
-                if (fVerboseLevel > REST_Info) fHeaderFrame[i].Show();
-                warning << "trying to skip this event and find next header..." << endl;
+                RESTWarning << "Event " << fCurrentEvent << " : error when reading next frame header" << RESTendl;
+                RESTWarning << "in file " << i << " \"" << fInputFileNames[i] << "\"" << RESTendl;
+                if (fVerboseLevel > TRestStringOutput::REST_Verbose_Level::REST_Info) fHeaderFrame[i].Show();
+                RESTWarning << "trying to skip this event and find next header..." << RESTendl;
                 fileerrors[i] += 1;
-                REST_Verbose_Level tmp = fVerboseLevel;
+                TRestStringOutput::REST_Verbose_Level tmp = fVerboseLevel;
                 bool found = false;
-                fVerboseLevel = REST_Silent;
+                fVerboseLevel = TRestStringOutput::REST_Verbose_Level::REST_Silent;
                 for (int k = 0; k < 1088; k++)  // fullreadoutsize(278528)/headersize(256)=1088
                 {
                     if (fread(fHeaderFrame[i].frameHeader, 256, 1, fInputFiles[i]) != 1 ||
@@ -353,9 +353,9 @@ bool TRestRawMultiCoBoAsAdToSignalProcess::FillBuffer() {
                     totalBytesReaded += 256;
                     if (ReadFrameHeader(fHeaderFrame[i])) {
                         fVerboseLevel = tmp;
-                        warning << "Successfully found next header (EventId : " << fHeaderFrame[i].eventIdx
-                                << ")" << endl;
-                        if (fVerboseLevel > REST_Info) fHeaderFrame[i].Show();
+                        RESTWarning << "Successfully found next header (EventId : " << fHeaderFrame[i].eventIdx
+                                << ")" << RESTendl;
+                        if (fVerboseLevel > TRestStringOutput::REST_Verbose_Level::REST_Info) fHeaderFrame[i].Show();
                         cout << endl;
                         // GetChar();
                         found = true;
@@ -413,49 +413,49 @@ bool TRestRawMultiCoBoAsAdToSignalProcess::ReadFrameHeader(CoBoHeaderFrame& HdrF
 
     if (HdrFrame.frameType == 1) {
         if (HdrFrame.itemSize != 4) {
-            warning << "unsupported item size!" << endl;
+            RESTWarning << "unsupported item size!" << RESTendl;
             return false;
         }
 
     } else if (HdrFrame.frameType == 2) {
         if (HdrFrame.itemSize != 2) {
-            warning << "unsupported item size!" << endl;
+            RESTWarning << "unsupported item size!" << RESTendl;
             return false;
         }
         if (HdrFrame.nItems != 139264) {
-            warning << "unsupported nItems!" << endl;
+            RESTWarning << "unsupported nItems!" << RESTendl;
             return false;
         }
     } else {
-        warning << "unknown frame type" << endl;
+        RESTWarning << "unknown frame type" << RESTendl;
         return false;
     }
 
     // warning<<"revision: "<<revision<<endl;
     if (HdrFrame.revision != 5) {
-        warning << "unsupported revision!" << endl;
+        RESTWarning << "unsupported revision!" << RESTendl;
         return false;
     }
 
     // warning<<"frameHeaderSize: "<<frameHeaderSize<<endl;
     if (HdrFrame.headerSize != 1) {
-        warning << "unsupported frameHeader size!" << endl;
+        RESTWarning << "unsupported frameHeader size!" << RESTendl;
         return false;
     }
 
     // warning<<"readOffset: "<<readOffset<<endl;
     if (HdrFrame.readOffset != 0) {
-        warning << "unsupported readOffset!" << endl;
+        RESTWarning << "unsupported readOffset!" << RESTendl;
         return false;
     }
 
     if (HdrFrame.status) {
-        warning << "bad frame!" << endl;
+        RESTWarning << "bad frame!" << RESTendl;
         return false;
     }
 
     if (HdrFrame.nItems * HdrFrame.itemSize + 256 != HdrFrame.frameSize) {
-        warning << "Event " << fCurrentEvent << " : item number and frame size unmatch!" << endl;
+        RESTWarning << "Event " << fCurrentEvent << " : item number and frame size unmatch!" << RESTendl;
 
         // sometimes there is a itemnumber-framesize unmatch problem
         // nItems*itemSize(=4)+256=frameSize

--- a/src/TRestRawMultiFEMINOSToSignalProcess.cxx
+++ b/src/TRestRawMultiFEMINOSToSignalProcess.cxx
@@ -216,7 +216,7 @@ void TRestRawMultiFEMINOSToSignalProcess::Initialize() {
 }
 
 void TRestRawMultiFEMINOSToSignalProcess::InitProcess() {
-    debug << "TRestRawMultiFeminos::InitProcess" << endl;
+    RESTDebug << "TRestRawMultiFeminos::InitProcess" << RESTendl;
     // Reading binary file header
 
     LoadDetectorSetupData();
@@ -248,7 +248,7 @@ void TRestRawMultiFEMINOSToSignalProcess::InitProcess() {
         totalBytesReaded += sizeof(int);
 
         tStart = tt;
-        debug << "Timestamp : " << tt << " - " << tStart << endl;
+        RESTDebug << "Timestamp : " << tt << " - " << tStart << RESTendl;
     }
 
     if (ORIGINAL_MCLIENT) {
@@ -266,7 +266,7 @@ void TRestRawMultiFEMINOSToSignalProcess::InitProcess() {
 }
 
 TRestEvent* TRestRawMultiFEMINOSToSignalProcess::ProcessEvent(TRestEvent* inputEvent) {
-    if (GetVerboseLevel() >= REST_Debug) cout << "TRestRawMultiFEMINOSToSignalProcess::ProcessEvent" << endl;
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) cout << "TRestRawMultiFEMINOSToSignalProcess::ProcessEvent" << endl;
 
     while (1) {
         unsigned short* sh;
@@ -289,7 +289,7 @@ TRestEvent* TRestRawMultiFEMINOSToSignalProcess::ProcessEvent(TRestEvent* inputE
             while (!done) {
                 // Read one short word
                 if (fread(sh, sizeof(unsigned short), 1, fInputBinFile) != 1) {
-                    debug << "End of file reached." << endl;
+                    RESTDebug << "End of file reached." << RESTendl;
 
                     // The processing thread will be finished when return nullptr is reached
                     return nullptr;
@@ -297,11 +297,11 @@ TRestEvent* TRestRawMultiFEMINOSToSignalProcess::ProcessEvent(TRestEvent* inputE
                 totalBytesReaded += sizeof(unsigned short);
 
                 if ((*sh & PFX_0_BIT_CONTENT_MASK) == PFX_START_OF_BUILT_EVENT) {
-                    if (GetVerboseLevel() >= REST_Debug) printf("***** Start of Built Event *****\n");
-                    if (GetVerboseLevel() >= REST_Debug) GetChar();
+                    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) printf("***** Start of Built Event *****\n");
+                    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) GetChar();
                 } else if ((*sh & PFX_0_BIT_CONTENT_MASK) == PFX_END_OF_BUILT_EVENT) {
-                    if (GetVerboseLevel() >= REST_Debug) printf("***** End of Built Event *****\n\n");
-                    if (GetVerboseLevel() >= REST_Debug) GetChar();
+                    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) printf("***** End of Built Event *****\n\n");
+                    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) GetChar();
                     endOfEvent = true;
                     done = 1;
                 } else if ((*sh & PFX_0_BIT_CONTENT_MASK) == PFX_SOBE_SIZE) {
@@ -369,14 +369,14 @@ TRestEvent* TRestRawMultiFEMINOSToSignalProcess::ProcessEvent(TRestEvent* inputE
             fLastEventId = 0;
         }
 
-        if (GetVerboseLevel() >= REST_Info) {
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Info) {
             cout << "------------------------------------------" << endl;
             cout << "Event ID : " << fSignalEvent->GetID() << endl;
             cout << "Time stamp : " << fSignalEvent->GetTimeStamp() << endl;
             cout << "Number of Signals : " << fSignalEvent->GetNumberOfSignals() << endl;
             cout << "------------------------------------------" << endl;
 
-            if (GetVerboseLevel() >= REST_Debug) {
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
                 for (Int_t n = 0; n < fSignalEvent->GetNumberOfSignals(); n++)
                     cout << "Signal N : " << n << " daq id : " << fSignalEvent->GetSignal(n)->GetID() << endl;
                 GetChar();
@@ -386,7 +386,7 @@ TRestEvent* TRestRawMultiFEMINOSToSignalProcess::ProcessEvent(TRestEvent* inputE
         if (fSignalEvent->GetNumberOfSignals() != 0) {
             return fSignalEvent;
         } else {
-            warning << "blank event " << fSignalEvent->GetID() << "! skipping..." << endl;
+            RESTWarning << "blank event " << fSignalEvent->GetID() << "! skipping..." << RESTendl;
         }
     }
 
@@ -411,7 +411,7 @@ Bool_t TRestRawMultiFEMINOSToSignalProcess::ReadFrame(void* fr, int fr_sz) {
     done = 0;
     si = 0;
 
-    if (GetVerboseLevel() >= REST_Debug) printf("ReadFrame: Frame payload: %d bytes\n", fr_sz);
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) printf("ReadFrame: Frame payload: %d bytes\n", fr_sz);
 
     Int_t showSamples = fShowSamples;
 
@@ -432,7 +432,7 @@ Bool_t TRestRawMultiFEMINOSToSignalProcess::ReadFrame(void* fr, int fr_sz) {
                 nChannels++;
             }
 
-            if (GetVerboseLevel() >= REST_Debug)
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
                 printf("ReadFrame: Card %02d Chip %01d Daq Channel %02d\n", cardNumber, chipNumber,
                        daqChannel);
             p++;
@@ -445,7 +445,7 @@ Bool_t TRestRawMultiFEMINOSToSignalProcess::ReadFrame(void* fr, int fr_sz) {
         // Is it a prefix for 12-bit content?
         else if ((*p & PFX_12_BIT_CONTENT_MASK) == PFX_ADC_SAMPLE) {
             r0 = GET_ADC_DATA(*p);
-            if (GetVerboseLevel() >= REST_Debug) {
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
                 if (showSamples > 0) printf("ReadFrame: %03d 0x%04x (%4d)\n", si, r0, r0);
                 showSamples--;
             }
@@ -456,7 +456,7 @@ Bool_t TRestRawMultiFEMINOSToSignalProcess::ReadFrame(void* fr, int fr_sz) {
         // Is it a prefix for 4-bit content?
         else if ((*p & PFX_4_BIT_CONTENT_MASK) == PFX_START_OF_EVENT) {
             r0 = GET_EVENT_TYPE(*p);
-            if (GetVerboseLevel() >= REST_Debug) printf("ReadFrame: -- Start of Event (Type %01d) --\n", r0);
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) printf("ReadFrame: -- Start of Event (Type %01d) --\n", r0);
             p++;
 
             // Time Stamp lower 16-bit
@@ -471,7 +471,7 @@ Bool_t TRestRawMultiFEMINOSToSignalProcess::ReadFrame(void* fr, int fr_sz) {
             r2 = *p;
             p++;
 
-            if (GetVerboseLevel() >= REST_Debug) {
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
                 printf("ReadFrame: Time 0x%04x 0x%04x 0x%04x\n", r2, r1, r0);
                 printf("Timestamp: 0x%04x 0x%04x 0x%04x\n", r2, r1, r0);
                 cout << "TimeStamp " << tStart + (2147483648 * r2 + 32768 * r1 + r0) * 2e-8 << endl;
@@ -488,7 +488,7 @@ Bool_t TRestRawMultiFEMINOSToSignalProcess::ReadFrame(void* fr, int fr_sz) {
             p++;
 
             tmp = (((unsigned int)n1) << 16) | ((unsigned int)n0);
-            if (GetVerboseLevel() >= REST_Info) printf("ReadFrame: Event_Count 0x%08x (%d)\n", tmp, tmp);
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Info) printf("ReadFrame: Event_Count 0x%08x (%d)\n", tmp, tmp);
 
             // Some times the end of the frame contains the header of the next event.
             // Then, in the attempt to read the header of next event, we must avoid
@@ -524,9 +524,9 @@ Bool_t TRestRawMultiFEMINOSToSignalProcess::ReadFrame(void* fr, int fr_sz) {
             p++;
             tmp = tmp + (unsigned int)*p;
             p++;
-            if (GetVerboseLevel() >= REST_Debug)
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
                 printf("ReadFrame: ----- End of Event ----- (size %d bytes)\n", tmp);
-            if (GetVerboseLevel() >= REST_Debug) GetChar();
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) GetChar();
 
             if (fElectronicsType == "SingleFeminos") endOfEvent = true;
         }
@@ -536,14 +536,14 @@ Bool_t TRestRawMultiFEMINOSToSignalProcess::ReadFrame(void* fr, int fr_sz) {
             if (sgnl.GetSignalID() >= 0 && sgnl.GetNumberOfPoints() >= fMinPoints)
                 fSignalEvent->AddSignal(sgnl);
 
-            if (GetVerboseLevel() >= REST_Debug) printf("ReadFrame: ----- End of Frame -----\n");
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) printf("ReadFrame: ----- End of Frame -----\n");
             p++;
             done = 1;
         } else if (*p == PFX_START_OF_BUILT_EVENT) {
-            if (GetVerboseLevel() >= REST_Debug) printf("ReadFrame: ***** Start of Built Event *****\n");
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) printf("ReadFrame: ***** Start of Built Event *****\n");
             p++;
         } else if (*p == PFX_END_OF_BUILT_EVENT) {
-            if (GetVerboseLevel() >= REST_Debug) printf("ReadFrame: ***** End of Built Event *****\n\n");
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) printf("ReadFrame: ***** End of Built Event *****\n\n");
             p++;
         } else if (*p == PFX_SOBE_SIZE) {
             // Skip header
@@ -557,7 +557,7 @@ Bool_t TRestRawMultiFEMINOSToSignalProcess::ReadFrame(void* fr, int fr_sz) {
             p++;
             tmp_i[0] = (int)((r1 << 16) | (r0));
 
-            if (GetVerboseLevel() >= REST_Debug)
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
                 printf("ReadFrame: ***** Start of Built Event - Size = %d bytes *****\n", tmp_i[0]);
         } else {
             p++;

--- a/src/TRestRawSignalAnalysisProcess.cxx
+++ b/src/TRestRawSignalAnalysisProcess.cxx
@@ -478,7 +478,7 @@ TRestEvent* TRestRawSignalAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) 
     SetObservableValue("MaxPeakTimeDelay", peakTimeDelay);
     SetObservableValue("AveragePeakTime", peakTimeAverage);
 
-    if (GetVerboseLevel() >= REST_Debug) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         for (auto i : fObservablesDefined) {
             fAnalysisTree->PrintObservable(i.second);
         }

--- a/src/TRestRawSignalChannelActivityProcess.cxx
+++ b/src/TRestRawSignalChannelActivityProcess.cxx
@@ -176,7 +176,7 @@ void TRestRawSignalChannelActivityProcess::InitProcess() {
     fReadout = GetMetadata<TRestDetectorReadout>();
 
     debug << "TRestRawSignalChannelActivityProcess::InitProcess. Readout pointer : " << fReadout << endl;
-    if (GetVerboseLevel() >= REST_Info && fReadout) fReadout->PrintMetadata();
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Info && fReadout) fReadout->PrintMetadata();
 #endif
 
     if (!fReadOnly) {
@@ -263,7 +263,7 @@ TRestEvent* TRestRawSignalChannelActivityProcess::ProcessEvent(TRestEvent* input
         }
     }
 
-    if (GetVerboseLevel() >= REST_Debug) fAnalysisTree->PrintObservables();
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) fAnalysisTree->PrintObservables();
 
     return fSignalEvent;
 }

--- a/src/TRestRawSignalConvolutionFittingProcess.cxx
+++ b/src/TRestRawSignalConvolutionFittingProcess.cxx
@@ -188,8 +188,8 @@ TRestEvent* TRestRawSignalConvolutionFittingProcess::ProcessEvent(TRestEvent* in
     // no need for verbose copy now
     fRawSignalEvent = (TRestRawSignalEvent*)inputEvent;
 
-    debug << "TRestRawSignalConvolutionFittingProcess::ProcessEvent. Event ID : " << fRawSignalEvent->GetID()
-          << endl;
+    RESTDebug << "TRestRawSignalConvolutionFittingProcess::ProcessEvent. Event ID : " << fRawSignalEvent->GetID()
+          << RESTendl;
 
     Double_t SigmaMean = 0;
     Double_t Sigma[fRawSignalEvent->GetNumberOfSignals()];
@@ -300,15 +300,15 @@ TRestEvent* TRestRawSignalConvolutionFittingProcess::ProcessEvent(TRestEvent* in
     RatioSigmaMaxPeakMean = RatioSigmaMaxPeakMean / fRawSignalEvent->GetNumberOfSignals();
     SetObservableValue("FitRatioSigmaMaxPeakMean", RatioSigmaMaxPeakMean);
 
-    debug << "SigmaMean: " << SigmaMean << endl;
-    debug << "SigmaMeanStdDev: " << SigmaMeanStdDev << endl;
-    debug << "ChiSquareMean: " << ChiSquareMean << endl;
-    debug << "RatioSigmaMaxPeakMean: " << RatioSigmaMaxPeakMean << endl;
+    RESTDebug << "SigmaMean: " << SigmaMean << RESTendl;
+    RESTDebug << "SigmaMeanStdDev: " << SigmaMeanStdDev << RESTendl;
+    RESTDebug << "ChiSquareMean: " << ChiSquareMean << RESTendl;
+    RESTDebug << "RatioSigmaMaxPeakMean: " << RatioSigmaMaxPeakMean << RESTendl;
     for (int k = 0; k < fRawSignalEvent->GetNumberOfSignals(); k++) {
-        debug << "Standard deviation of signal number " << k << ": " << Sigma[k] << endl;
-        debug << "Chi square of fit signal number " << k << ": " << ChiSquare[k] << endl;
-        debug << "Sandard deviation divided by amplitude of signal number " << k << ": "
-              << RatioSigmaMaxPeak[k] << endl;
+        RESTDebug << "Standard deviation of signal number " << k << ": " << Sigma[k] << RESTendl;
+        RESTDebug << "Chi square of fit signal number " << k << ": " << ChiSquare[k] << RESTendl;
+        RESTDebug << "Sandard deviation divided by amplitude of signal number " << k << ": "
+              << RatioSigmaMaxPeak[k] << RESTendl;
     }
 
     /// We define (or re-define) the baseline range and calculation range of our

--- a/src/TRestRawSignalEvent.cxx
+++ b/src/TRestRawSignalEvent.cxx
@@ -476,7 +476,7 @@ TPad* TRestRawSignalEvent::DrawEvent(const TString& option) {
             else if (str.find("-") != string::npos)
                 optList_4 = Vector_cast<string, TString>(Split((string)tmpStr3, "-"));
             else
-                RESTFerr << "TRestRawSignalEvent::DrawEvent not valid ids format!" << RESTendl;
+                RESTError << "TRestRawSignalEvent::DrawEvent not valid ids format!" << RESTendl;
 
             sRangeInit = StringToInteger((string)optList_4[0]);
             sRangeEnd = StringToInteger((string)optList_4[1]);

--- a/src/TRestRawSignalEvent.cxx
+++ b/src/TRestRawSignalEvent.cxx
@@ -476,7 +476,7 @@ TPad* TRestRawSignalEvent::DrawEvent(const TString& option) {
             else if (str.find("-") != string::npos)
                 optList_4 = Vector_cast<string, TString>(Split((string)tmpStr3, "-"));
             else
-                ferr << "TRestRawSignalEvent::DrawEvent not valid ids format!" << endl;
+                RESTFerr << "TRestRawSignalEvent::DrawEvent not valid ids format!" << RESTendl;
 
             sRangeInit = StringToInteger((string)optList_4[0]);
             sRangeEnd = StringToInteger((string)optList_4[1]);
@@ -499,11 +499,11 @@ TPad* TRestRawSignalEvent::DrawEvent(const TString& option) {
 
         // If threshold and baseline options are given
         if (ThresCheck && BLCheck) {
-            debug << "Draw only good signals with: " << endl;
-            debug << "  Signal threshold: " << signalTh << endl;
-            debug << "  Point threshold: " << pointTh << endl;
-            debug << "  Points over threshold: " << nOver << endl;
-            debug << "  Base line range: (" << baseLineRangeInit << "," << baseLineRangeEnd << ")" << endl;
+            RESTDebug << "Draw only good signals with: " << RESTendl;
+            RESTDebug << "  Signal threshold: " << signalTh << RESTendl;
+            RESTDebug << "  Point threshold: " << pointTh << RESTendl;
+            RESTDebug << "  Points over threshold: " << nOver << RESTendl;
+            RESTDebug << "  Base line range: (" << baseLineRangeInit << "," << baseLineRangeEnd << ")" << RESTendl;
 
             for (int n = 0; n < nSignals; n++) {
                 fSignal[n].CalculateBaseLine(baseLineRangeInit, baseLineRangeEnd);
@@ -540,8 +540,8 @@ TPad* TRestRawSignalEvent::DrawEvent(const TString& option) {
         if (separation != string::npos) {
             TString firstSignal = optList[0](0, separation);
             TString lastSignal = optList[0](separation + 1, str.size());
-            debug << "First signal: " << firstSignal << endl;
-            debug << "Last signal: " << lastSignal << endl;
+            RESTDebug << "First signal: " << firstSignal << RESTendl;
+            RESTDebug << "Last signal: " << lastSignal << RESTendl;
 
             if (StringToInteger((string)lastSignal) >= fSignal.size()) {
                 fPad->SetTitle("No Such Signal");
@@ -552,12 +552,12 @@ TPad* TRestRawSignalEvent::DrawEvent(const TString& option) {
             sprintf(title, "Event ID %d", this->GetID());
 
             if (ThresCheck && BLCheck) {
-                debug << "Draw only good signals with: " << endl;
-                debug << "  Signal threshold: " << signalTh << endl;
-                debug << "  Point threshold: " << pointTh << endl;
-                debug << "  Points over threshold: " << nOver << endl;
-                debug << "  Base line range: (" << baseLineRangeInit << "," << baseLineRangeEnd << ")"
-                      << endl;
+                RESTDebug << "Draw only good signals with: " << RESTendl;
+                RESTDebug << "  Signal threshold: " << signalTh << RESTendl;
+                RESTDebug << "  Point threshold: " << pointTh << RESTendl;
+                RESTDebug << "  Points over threshold: " << nOver << RESTendl;
+                RESTDebug << "  Base line range: (" << baseLineRangeInit << "," << baseLineRangeEnd << ")"
+                      << RESTendl;
 
                 for (int n = 0; n < nSignals; n++) {
                     if (n < StringToInteger((string)firstSignal) || n > StringToInteger((string)lastSignal))
@@ -619,7 +619,7 @@ void TRestRawSignalEvent::DrawSignals(TPad* pad, const std::vector<Int_t>& signa
         color++;
     }
 
-    debug << "Max SID " << maxSID << endl;
+    RESTDebug << "Max SID " << maxSID << RESTendl;
 
     if (maxSID == -1) {
         cout << "No signals ID found" << endl;
@@ -738,7 +738,7 @@ TPad* TRestRawSignalEvent::DrawSignal(Int_t signal, TString option) {
     sgnl->CalculateBaseLine(baseLineRangeInit, baseLineRangeEnd);
     sgnl->InitializePointsOverThreshold(TVector2(pointTh, signalTh), nOver);
 
-    info << "Drawing signal. Event ID : " << this->GetID() << " Signal ID : " << sgnl->GetID() << endl;
+    RESTInfo << "Drawing signal. Event ID : " << this->GetID() << " Signal ID : " << sgnl->GetID() << RESTendl;
 
     for (int n = 0; n < sgnl->GetNumberOfPoints(); n++) gr->SetPoint(n, n, sgnl->GetData(n));
 

--- a/src/TRestRawSignalFittingProcess.cxx
+++ b/src/TRestRawSignalFittingProcess.cxx
@@ -177,7 +177,7 @@ TRestEvent* TRestRawSignalFittingProcess::ProcessEvent(TRestEvent* inputEvent) {
     // no need for verbose copy now
     fRawSignalEvent = (TRestRawSignalEvent*)inputEvent;
 
-    debug << "TRestRawSignalFittingProcess::ProcessEvent. Event ID : " << fRawSignalEvent->GetID() << endl;
+    RESTDebug << "TRestRawSignalFittingProcess::ProcessEvent. Event ID : " << fRawSignalEvent->GetID() << RESTendl;
 
     Double_t SigmaMean = 0;
     Double_t Sigma[fRawSignalEvent->GetNumberOfSignals()];
@@ -279,15 +279,15 @@ TRestEvent* TRestRawSignalFittingProcess::ProcessEvent(TRestEvent* inputEvent) {
     RatioSigmaMaxPeakMean = RatioSigmaMaxPeakMean / fRawSignalEvent->GetNumberOfSignals();
     SetObservableValue("FitRatioSigmaMaxPeakMean", RatioSigmaMaxPeakMean);
 
-    debug << "SigmaMean: " << SigmaMean << endl;
-    debug << "SigmaMeanStdDev: " << SigmaMeanStdDev << endl;
-    debug << "ChiSquareMean: " << ChiSquareMean << endl;
-    debug << "RatioSigmaMaxPeakMean: " << RatioSigmaMaxPeakMean << endl;
+    RESTDebug << "SigmaMean: " << SigmaMean << RESTendl;
+    RESTDebug << "SigmaMeanStdDev: " << SigmaMeanStdDev << RESTendl;
+    RESTDebug << "ChiSquareMean: " << ChiSquareMean << RESTendl;
+    RESTDebug << "RatioSigmaMaxPeakMean: " << RatioSigmaMaxPeakMean << RESTendl;
     for (int k = 0; k < fRawSignalEvent->GetNumberOfSignals(); k++) {
-        debug << "Standard deviation of signal number " << k << ": " << Sigma[k] << endl;
-        debug << "Chi square of fit signal number " << k << ": " << ChiSquare[k] << endl;
-        debug << "Sandard deviation divided by amplitude of signal number " << k << ": "
-              << RatioSigmaMaxPeak[k] << endl;
+        RESTDebug << "Standard deviation of signal number " << k << ": " << Sigma[k] << RESTendl;
+        RESTDebug << "Chi square of fit signal number " << k << ": " << ChiSquare[k] << RESTendl;
+        RESTDebug << "Sandard deviation divided by amplitude of signal number " << k << ": "
+              << RatioSigmaMaxPeak[k] << RESTendl;
     }
 
     /// We define (or re-define) the baseline range and calculation range of our

--- a/src/TRestRawSignalGeneralFitProcess.cxx
+++ b/src/TRestRawSignalGeneralFitProcess.cxx
@@ -138,7 +138,7 @@ TRestEvent* TRestRawSignalGeneralFitProcess::ProcessEvent(TRestEvent* inputEvent
     // no need for verbose copy now
     fRawSignalEvent = (TRestRawSignalEvent*)inputEvent;
 
-    debug << "TRestRawSignalGeneralFitProcess::ProcessEvent. Event ID : " << fRawSignalEvent->GetID() << endl;
+    RESTDebug << "TRestRawSignalGeneralFitProcess::ProcessEvent. Event ID : " << fRawSignalEvent->GetID() << RESTendl;
 
     Double_t SigmaMean = 0;
     Double_t Sigma[fRawSignalEvent->GetNumberOfSignals()];
@@ -215,8 +215,8 @@ TRestEvent* TRestRawSignalGeneralFitProcess::ProcessEvent(TRestEvent* inputEvent
         for (int i = 0; i < fFitFunc->GetNpar(); i++) {
             param[i][singleSignal->GetID()] = fFitFunc->GetParameter(i);
             paramErr[i][singleSignal->GetID()] = fFitFunc->GetParError(i);
-            debug << "Parameter " << i << ": " << param[i][singleSignal->GetID()] << endl;
-            debug << "Error parameter " << i << ": " << paramErr[i][singleSignal->GetID()] << endl;
+            RESTDebug << "Parameter " << i << ": " << param[i][singleSignal->GetID()] << RESTendl;
+            RESTDebug << "Error parameter " << i << ": " << paramErr[i][singleSignal->GetID()] << RESTendl;
         }
 
         /*baselineFit[singleSignal->GetID()] = f->GetParameter(0);
@@ -264,15 +264,15 @@ TRestEvent* TRestRawSignalGeneralFitProcess::ProcessEvent(TRestEvent* inputEvent
     RatioSigmaMaxPeakMean = RatioSigmaMaxPeakMean / fRawSignalEvent->GetNumberOfSignals();
     SetObservableValue("FitRatioSigmaMaxPeakMean", RatioSigmaMaxPeakMean);
 
-    debug << "SigmaMean: " << SigmaMean << endl;
-    debug << "SigmaMeanStdDev: " << SigmaMeanStdDev << endl;
-    debug << "ChiSquareMean: " << ChiSquareMean << endl;
-    debug << "RatioSigmaMaxPeakMean: " << RatioSigmaMaxPeakMean << endl;
+    RESTDebug << "SigmaMean: " << SigmaMean << RESTendl;
+    RESTDebug << "SigmaMeanStdDev: " << SigmaMeanStdDev << RESTendl;
+    RESTDebug << "ChiSquareMean: " << ChiSquareMean << RESTendl;
+    RESTDebug << "RatioSigmaMaxPeakMean: " << RatioSigmaMaxPeakMean << RESTendl;
     for (int k = 0; k < fRawSignalEvent->GetNumberOfSignals(); k++) {
-        debug << "Standard deviation of signal number " << k << ": " << Sigma[k] << endl;
-        debug << "Chi square of fit signal number " << k << ": " << ChiSquare[k] << endl;
-        debug << "Sandard deviation divided by amplitude of signal number " << k << ": "
-              << RatioSigmaMaxPeak[k] << endl;
+        RESTDebug << "Standard deviation of signal number " << k << ": " << Sigma[k] << RESTendl;
+        RESTDebug << "Chi square of fit signal number " << k << ": " << ChiSquare[k] << RESTendl;
+        RESTDebug << "Sandard deviation divided by amplitude of signal number " << k << ": "
+              << RatioSigmaMaxPeak[k] << RESTendl;
     }
 
     /// We define (or re-define) the baseline range and calculation range of our

--- a/src/TRestRawSignalRecoverChannelsProcess.cxx
+++ b/src/TRestRawSignalRecoverChannelsProcess.cxx
@@ -151,9 +151,9 @@ void TRestRawSignalRecoverChannelsProcess::InitProcess() {
         exit(-1);
     }
 #else
-    RESTFerr << "TRestRawSignalRecoverChannelsProcess will not be active." << RESTendl;
-    RESTFerr << "REST was not compiled with detectorlib" << RESTendl;
-    RESTFerr << "Please, remove this process or compile REST with detector library" << RESTendl;
+    RESTError << "TRestRawSignalRecoverChannelsProcess will not be active." << RESTendl;
+    RESTError << "REST was not compiled with detectorlib" << RESTendl;
+    RESTError << "Please, remove this process or compile REST with detector library" << RESTendl;
 #endif
 }
 

--- a/src/TRestRawSignalRecoverChannelsProcess.cxx
+++ b/src/TRestRawSignalRecoverChannelsProcess.cxx
@@ -151,9 +151,9 @@ void TRestRawSignalRecoverChannelsProcess::InitProcess() {
         exit(-1);
     }
 #else
-    ferr << "TRestRawSignalRecoverChannelsProcess will not be active." << endl;
-    ferr << "REST was not compiled with detectorlib" << endl;
-    ferr << "Please, remove this process or compile REST with detector library" << endl;
+    RESTFerr << "TRestRawSignalRecoverChannelsProcess will not be active." << RESTendl;
+    RESTFerr << "REST was not compiled with detectorlib" << RESTendl;
+    RESTFerr << "Please, remove this process or compile REST with detector library" << RESTendl;
 #endif
 }
 

--- a/src/TRestRawSignalRemoveChannelsProcess.cxx
+++ b/src/TRestRawSignalRemoveChannelsProcess.cxx
@@ -153,13 +153,13 @@ TRestEvent* TRestRawSignalRemoveChannelsProcess::ProcessEvent(TRestEvent* inputE
 
         if (!removeChannel) fOutputSignalEvent->AddSignal(*sgnl);
 
-        if (GetVerboseLevel() >= REST_Extreme) cout << "Channel ID : " << sgnl->GetID() << endl;
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) cout << "Channel ID : " << sgnl->GetID() << endl;
 
-        if (GetVerboseLevel() >= REST_Debug && removeChannel)
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug && removeChannel)
             cout << "Removing channel id : " << sgnl->GetID() << endl;
     }
 
-    if (GetVerboseLevel() >= REST_Extreme) GetChar();
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) GetChar();
 
     return fOutputSignalEvent;
 }

--- a/src/TRestRawSignalShapingProcess.cxx
+++ b/src/TRestRawSignalShapingProcess.cxx
@@ -240,7 +240,7 @@ TRestEvent* TRestRawSignalShapingProcess::ProcessEvent(TRestEvent* inputEvent) {
             response[i] = TMath::Exp(-3. * coeff) * coeff * coeff * coeff * sin(coeff);
         }
     } else {
-        if (GetVerboseLevel() >= REST_Warning)
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Warning)
             cout << "REST WARNING. Shaping type : " << fShapingType << " is not defined!!" << endl;
         return nullptr;
     }

--- a/src/TRestRawSignalViewerProcess.cxx
+++ b/src/TRestRawSignalViewerProcess.cxx
@@ -162,9 +162,9 @@ TRestEvent* TRestRawSignalViewerProcess::ProcessEvent(TRestEvent* inputEvent) {
         pad2->Draw();
         fCanvas->Update();
 
-        RESTFout.setborder("");
-        RESTFout.setorientation(TRestStringOutput::REST_Display_Orientation::kLeft);
-        RESTFout << "Press Enter to continue\nPress Esc to stop viewing\nPress n/p to "
+        RESTcout.setborder("");
+        RESTcout.setorientation(TRestStringOutput::REST_Display_Orientation::kLeft);
+        RESTcout << "Press Enter to continue\nPress Esc to stop viewing\nPress n/p to "
                 "switch signals"
              << RESTendl;
 

--- a/src/TRestRawSignalViewerProcess.cxx
+++ b/src/TRestRawSignalViewerProcess.cxx
@@ -147,7 +147,7 @@ TRestEvent* TRestRawSignalViewerProcess::ProcessEvent(TRestEvent* inputEvent) {
     if (eveCounter >= fDrawRefresh) {
         eveCounter = 0;
         sgnCounter = 0;
-        if (GetVerboseLevel() >= REST_Debug) {
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
             GetAnalysisTree()->PrintObservables();
         }
         for (auto object : fDrawingObjects) {
@@ -162,11 +162,11 @@ TRestEvent* TRestRawSignalViewerProcess::ProcessEvent(TRestEvent* inputEvent) {
         pad2->Draw();
         fCanvas->Update();
 
-        fout.setborder("");
-        fout.setorientation(1);
-        fout << "Press Enter to continue\nPress Esc to stop viewing\nPress n/p to "
+        RESTFout.setborder("");
+        RESTFout.setorientation(TRestStringOutput::REST_Display_Orientation::kLeft);
+        RESTFout << "Press Enter to continue\nPress Esc to stop viewing\nPress n/p to "
                 "switch signals"
-             << endl;
+             << RESTendl;
 
         while (1) {
             int a = GetChar("");
@@ -188,7 +188,7 @@ TRestEvent* TRestRawSignalViewerProcess::ProcessEvent(TRestEvent* inputEvent) {
                     pad2->Draw();
                     fCanvas->Update();
                 } else {
-                    warning << "cannot plot signal with id " << sgnCounter << endl;
+                    RESTWarning << "cannot plot signal with id " << sgnCounter << RESTendl;
                 }
             } else if (a == 112 || a == 80)  // p
             {
@@ -199,7 +199,7 @@ TRestEvent* TRestRawSignalViewerProcess::ProcessEvent(TRestEvent* inputEvent) {
                     pad2->Draw();
                     fCanvas->Update();
                 } else {
-                    warning << "cannot plot signal with id " << sgnCounter << endl;
+                    RESTWarning << "cannot plot signal with id " << sgnCounter << RESTendl;
                 }
             }
             while (getchar() != '\n')
@@ -238,8 +238,8 @@ TPad* TRestRawSignalViewerProcess::DrawSignal(Int_t signal) {
 
     TRestRawSignal* sgnl = fSignalEvent->GetSignal(signal);
 
-    info << "Drawing signal. Event ID : " << fSignalEvent->GetID() << " Signal ID : " << sgnl->GetID()
-         << endl;
+    RESTInfo << "Drawing signal. Event ID : " << fSignalEvent->GetID() << " Signal ID : " << sgnl->GetID()
+         << RESTendl;
 
     for (int n = 0; n < sgnl->GetNumberOfPoints(); n++) gr->SetPoint(n, n, sgnl->GetData(n));
 

--- a/src/TRestRawTDSToSignalProcess.cxx
+++ b/src/TRestRawTDSToSignalProcess.cxx
@@ -86,9 +86,9 @@ void TRestRawTDSToSignalProcess::InitProcess() {
     nChannels = blockhead.NHits / blockhead.NEvents;
     fRate = blockhead.SRate;
     pulseDepth = blockhead.PSize;
-    debug << "nSamples " << nSamples << " NChannels " << nChannels << endl;
-    debug << "SRATE: " << (double)fRate << " PULSE DEPTH: " << pulseDepth
-          << " PRETRIGGER: " << blockhead.Pretrigger << endl;
+    RESTDebug << "nSamples " << nSamples << " NChannels " << nChannels << RESTendl;
+    RESTDebug << "SRATE: " << (double)fRate << " PULSE DEPTH: " << pulseDepth
+          << " PRETRIGGER: " << blockhead.Pretrigger << RESTendl;
     for (int i = 0; i < nChannels; i++) {
         fScale[i] = blockhead.mVdiv[i];
         negPolarity[i] = blockhead.NegPolarity[i];

--- a/src/TRestRawToSignalProcess.cxx
+++ b/src/TRestRawToSignalProcess.cxx
@@ -148,7 +148,7 @@ Bool_t TRestRawToSignalProcess::OpenInputFiles(vector<string> files) {
     if (nFiles > 0) {
         fInputBinFile = fInputFiles[0];
     } else {
-        RESTFerr << "No input file is opened, in process: " << this->ClassName() << "!" << RESTendl;
+        RESTError << "No input file is opened, in process: " << this->ClassName() << "!" << RESTendl;
         exit(1);
     }
 
@@ -159,7 +159,7 @@ Bool_t TRestRawToSignalProcess::OpenInputFiles(vector<string> files) {
 Bool_t TRestRawToSignalProcess::AddInputFile(string file) {
     for (int i = 0; i < fInputFileNames.size(); i++) {
         if (fInputFileNames[i] == file) {
-            RESTFerr << "file: \"" << file << "\" already added!" << RESTendl;
+            RESTError << "file: \"" << file << "\" already added!" << RESTendl;
             return false;
         }
     }

--- a/src/TRestRawToSignalProcess.cxx
+++ b/src/TRestRawToSignalProcess.cxx
@@ -120,7 +120,7 @@ void TRestRawToSignalProcess::InitFromConfigFile() {
         return;
     }
 
-    if (GetVerboseLevel() >= REST_Warning) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Warning) {
         cout << "REST WARNING: TRestRawToSignalProcess::InitFromConfigFile" << endl;
         cout << "Electronic type " << fElectronicsType << " not found " << endl;
         // cout << "Loading default config" << endl;
@@ -148,18 +148,18 @@ Bool_t TRestRawToSignalProcess::OpenInputFiles(vector<string> files) {
     if (nFiles > 0) {
         fInputBinFile = fInputFiles[0];
     } else {
-        ferr << "No input file is opened, in process: " << this->ClassName() << "!" << endl;
+        RESTFerr << "No input file is opened, in process: " << this->ClassName() << "!" << RESTendl;
         exit(1);
     }
 
-    debug << this->GetName() << " : opened " << nFiles << " files" << endl;
+    RESTDebug << this->GetName() << " : opened " << nFiles << " files" << RESTendl;
     return nFiles;
 }
 
 Bool_t TRestRawToSignalProcess::AddInputFile(string file) {
     for (int i = 0; i < fInputFileNames.size(); i++) {
         if (fInputFileNames[i] == file) {
-            ferr << "file: \"" << file << "\" already added!" << endl;
+            RESTFerr << "file: \"" << file << "\" already added!" << RESTendl;
             return false;
         }
     }
@@ -167,8 +167,8 @@ Bool_t TRestRawToSignalProcess::AddInputFile(string file) {
     FILE* f = fopen(file.c_str(), "rb");
 
     if (f == nullptr) {
-        warning << "REST WARNING. Input file for " << this->ClassName() << " does not exist!" << endl;
-        warning << "File : " << file << endl;
+        RESTWarning << "REST WARNING. Input file for " << this->ClassName() << " does not exist!" << RESTendl;
+        RESTWarning << "File : " << file << RESTendl;
         return false;
     }
 
@@ -198,15 +198,15 @@ Bool_t TRestRawToSignalProcess::ResetEntry() {
 void TRestRawToSignalProcess::PrintMetadata() {
     BeginPrintProcess();
 
-    metadata << " " << endl;
-    metadata << " ==================================== " << endl;
-    metadata << "DAQ : " << GetTitle() << endl;
-    metadata << "Electronics type : " << fElectronicsType << endl;
-    metadata << "Minimum number of points : " << fMinPoints << endl;
-    metadata << "All raw files open at beginning : " << fgKeepFileOpen << endl;
-    metadata << " ==================================== " << endl;
+    RESTMetadata << " " << RESTendl;
+    RESTMetadata << " ==================================== " << RESTendl;
+    RESTMetadata << "DAQ : " << GetTitle() << RESTendl;
+    RESTMetadata << "Electronics type : " << fElectronicsType << RESTendl;
+    RESTMetadata << "Minimum number of points : " << fMinPoints << RESTendl;
+    RESTMetadata << "All raw files open at beginning : " << fgKeepFileOpen << RESTendl;
+    RESTMetadata << " ==================================== " << RESTendl;
 
-    metadata << " " << endl;
+    RESTMetadata << " " << RESTendl;
 
     EndPrintProcess();
 }
@@ -220,12 +220,12 @@ Bool_t TRestRawToSignalProcess::GoToNextFile() {
             fclose(fInputBinFile);
             fInputBinFile = fopen(fInputFileNames[iCurFile].c_str(), "rb");
         }
-        info << "GoToNextFile(): Going to the next raw input file number " << iCurFile << " over " << nFiles
-             << endl;
-        info << "                Reading file name:  " << fInputFileNames[iCurFile] << endl;
+        RESTInfo << "GoToNextFile(): Going to the next raw input file number " << iCurFile << " over " << nFiles
+             << RESTendl;
+        RESTInfo << "                Reading file name:  " << fInputFileNames[iCurFile] << RESTendl;
         return true;
     } else {
-        info << "GoToNextFile(): No more file to read" << endl;
+        RESTInfo << "GoToNextFile(): No more file to read" << RESTendl;
     }
     return false;
 }

--- a/src/TRestRawUSTCToSignalProcess.cxx
+++ b/src/TRestRawUSTCToSignalProcess.cxx
@@ -110,10 +110,10 @@ void TRestRawUSTCToSignalProcess::InitProcess() {
     if ((!GetNextFrame(frame)) || (!ReadFrameData(frame))) {
         FixToNextFrame(fInputFiles[fCurrentFile]);
         if ((!GetNextFrame(frame)) || (!ReadFrameData(frame))) {
-            ferr << "TRestRawUSTCToSignalProcess: Failed to read the first data "
+            RESTFerr << "TRestRawUSTCToSignalProcess: Failed to read the first data "
                     "frame in file, may be wrong "
                     "input?"
-                 << endl;
+                 << RESTendl;
             exit(1);
         }
     }
@@ -122,8 +122,8 @@ void TRestRawUSTCToSignalProcess::InitProcess() {
     AddBuffer(frame);
 
     if (fCurrentEvent != 0) {
-        warning << "TRestRawUSTCToSignalProcess : first event is not with id 0 !" << endl;
-        warning << "The first Id is " << fCurrentEvent << ". May be input file not the first file?" << endl;
+        RESTWarning << "TRestRawUSTCToSignalProcess : first event is not with id 0 !" << RESTendl;
+        RESTWarning << "The first Id is " << fCurrentEvent << ". May be input file not the first file?" << RESTendl;
     }
 }
 
@@ -136,7 +136,7 @@ TRestEvent* TRestRawUSTCToSignalProcess::ProcessEvent(TRestEvent* inputEvent) {
             fSignalEvent->SetOK(false);
         }
         if (fEventBuffer[fCurrentBuffer].size() == 0) {
-            debug << "Blank event " << fCurrentEvent << " !" << endl;
+            RESTDebug << "Blank event " << fCurrentEvent << " !" << RESTendl;
             fCurrentEvent++;
             ClearBuffer();
         } else {
@@ -147,8 +147,8 @@ TRestEvent* TRestRawUSTCToSignalProcess::ProcessEvent(TRestEvent* inputEvent) {
     fSignalEvent->Initialize();
     fSignalEvent->SetID(fCurrentEvent);
 
-    debug << "------------------------------------" << endl;
-    debug << "Generating event with ID: " << fCurrentEvent << endl;
+    RESTDebug << "------------------------------------" << RESTendl;
+    RESTDebug << "Generating event with ID: " << fCurrentEvent << RESTendl;
 
     // some event level operation
     USTCDataFrame* frame0 = &fEventBuffer[fCurrentBuffer][0];
@@ -168,14 +168,14 @@ TRestEvent* TRestRawUSTCToSignalProcess::ProcessEvent(TRestEvent* inputEvent) {
             }
             fSignalEvent->AddSignal(sgnl);
 
-            debug << "AsAdId, AgetId, chnId, max value: " << frame->boardId << ", " << frame->chipId << ", "
-                  << frame->channelId << ", " << sgnl.GetMaxValue() << endl;
+            RESTDebug << "AsAdId, AgetId, chnId, max value: " << frame->boardId << ", " << frame->chipId << ", "
+                  << frame->channelId << ", " << sgnl.GetMaxValue() << RESTendl;
 
         } else {
-            warning << "TRestRawUSTCToSignalProcess : unmatched signal frame!" << endl;
-            warning << "ID (supposed, received): " << fCurrentEvent << ", " << frame->evId << endl;
-            warning << "Time (supposed, received) : " << evtTime << ", " << frame->eventTime << endl;
-            warning << endl;
+            RESTWarning << "TRestRawUSTCToSignalProcess : unmatched signal frame!" << RESTendl;
+            RESTWarning << "ID (supposed, received): " << fCurrentEvent << ", " << frame->evId << RESTendl;
+            RESTWarning << "Time (supposed, received) : " << evtTime << ", " << frame->eventTime << RESTendl;
+            RESTWarning << RESTendl;
             fSignalEvent->SetOK(false);
             fCurrentEvent++;
             ClearBuffer();
@@ -185,7 +185,7 @@ TRestEvent* TRestRawUSTCToSignalProcess::ProcessEvent(TRestEvent* inputEvent) {
 
     ClearBuffer();
 
-    if (GetVerboseLevel() >= REST_Debug) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         cout << "------------------------------------" << endl;
         GetChar();
     }
@@ -202,12 +202,12 @@ TRestEvent* TRestRawUSTCToSignalProcess::ProcessEvent(TRestEvent* inputEvent) {
 
 void TRestRawUSTCToSignalProcess::EndProcess() {
     for (int i = 0; i < errorevents.size(); i++) {
-        warning << "Event " << errorevents[i] << " contains error !" << endl;
+        RESTWarning << "Event " << errorevents[i] << " contains error !" << RESTendl;
     }
     if (errorevents.size() > 0 && unknownerrors > 0) {
-        warning << "There are also " << unknownerrors << " errors from unknown events! " << endl;
+        RESTWarning << "There are also " << unknownerrors << " errors from unknown events! " << RESTendl;
     } else if (unknownerrors > 0) {
-        warning << "There are " << unknownerrors << " errors from unknown events! " << endl;
+        RESTWarning << "There are " << unknownerrors << " errors from unknown events! " << RESTendl;
     }
 
     errorevents.clear();
@@ -234,7 +234,7 @@ bool TRestRawUSTCToSignalProcess::FillBuffer() {
             break;
         }
         if (!ReadFrameData(frame)) {
-            warning << "error reading frame data in file " << fCurrentFile << endl;
+            RESTWarning << "error reading frame data in file " << fCurrentFile << RESTendl;
             FixToNextFrame(fInputFiles[fCurrentFile]);
             GetNextFrame(frame);
             ReadFrameData(frame);
@@ -368,7 +368,7 @@ bool TRestRawUSTCToSignalProcess::GetNextFrame(USTCDataFrame& frame) {
     totalBytesReaded += DATA_SIZE;
 
     if (frame.data[0] * 0x100 + frame.data[1] != 0xEEEE) {
-        warning << "wrong header!" << endl;
+        RESTarning << "wrong header!" << RESTendl;
         return false;
     }
 #endif  // V4_Readout_Format
@@ -400,15 +400,15 @@ void TRestRawUSTCToSignalProcess::FixToNextFrame(FILE* f) {
                     break;
                 }
                 n += HEADER_SIZE;
-                warning << "successfully switched to next frame ( + " << n << " byte)" << endl;
-                warning << endl;
+                RESTWarning << "successfully switched to next frame ( + " << n << " byte)" << RESTendl;
+                RESTWarning << RESTendl;
                 break;
             }
         }
 #else
         if (!(buffer[0] ^ 0xff) && !(buffer[1] ^ 0xff) && !(buffer[2] ^ 0xff) && !(buffer[3] ^ 0xff)) {
-            warning << "successfully switched to next frame ( + " << n << " byte)" << endl;
-            warning << endl;
+            RESTWarning << "successfully switched to next frame ( + " << n << " byte)" << RESTendl;
+            RESTWarning << RESTendl;
             break;
         }
 #endif
@@ -524,19 +524,19 @@ bool TRestRawUSTCToSignalProcess::AddBuffer(USTCDataFrame& frame) {
     }
 #else
     if (frame.evId >= fCurrentEvent + fEventBuffer.size()) {
-        warning << "too large event id for buffering!" << endl;
-        warning << "this may due to the inconherence of event id. Increase the "
+        RESTWarning << "too large event id for buffering!" << RESTendl;
+        RESTWarning << "this may due to the inconherence of event id. Increase the "
                    "buffer number!"
-                << endl;
-        warning << "Current Event, Burrfering event : " << fCurrentEvent << ", " << frame.evId << endl;
+                << RESTendl;
+        RESTWarning << "Current Event, Burrfering event : " << fCurrentEvent << ", " << frame.evId << RESTendl;
         return false;
     }
     if (frame.evId < fCurrentEvent) {
-        warning << "skipping a signal from old event!" << endl;
-        warning << "the cause may be that too much events are mixing. Increase the "
+        RESTWarning << "skipping a signal from old event!" << RESTendl;
+        RESTWarning << "the cause may be that too much events are mixing. Increase the "
                    "buffer number!"
-                << endl;
-        warning << "Current Event, Burrfering event : " << fCurrentEvent << ", " << frame.evId << endl;
+                << RESTendl;
+        RESTWarning << "Current Event, Burrfering event : " << fCurrentEvent << ", " << frame.evId << RESTendl;
         return false;
     }
     int pos = frame.evId - fCurrentEvent + fCurrentBuffer;

--- a/src/TRestRawUSTCToSignalProcess.cxx
+++ b/src/TRestRawUSTCToSignalProcess.cxx
@@ -110,7 +110,7 @@ void TRestRawUSTCToSignalProcess::InitProcess() {
     if ((!GetNextFrame(frame)) || (!ReadFrameData(frame))) {
         FixToNextFrame(fInputFiles[fCurrentFile]);
         if ((!GetNextFrame(frame)) || (!ReadFrameData(frame))) {
-            RESTFerr << "TRestRawUSTCToSignalProcess: Failed to read the first data "
+            RESTError << "TRestRawUSTCToSignalProcess: Failed to read the first data "
                     "frame in file, may be wrong "
                     "input?"
                  << RESTendl;

--- a/src/TRestRawVetoAnalysisProcess.cxx
+++ b/src/TRestRawVetoAnalysisProcess.cxx
@@ -352,10 +352,10 @@ TRestEvent* TRestRawVetoAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
         }
     }
 
-    if (GetVerboseLevel() >= REST_Debug) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         fSignalEvent->PrintEvent();
 
-        if (GetVerboseLevel() >= REST_Extreme) GetChar();
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) GetChar();
     }
 
     return fSignalEvent;
@@ -429,29 +429,29 @@ void TRestRawVetoAnalysisProcess::PrintMetadata() {
 
     // Print output metadata using, metadata << endl;
     for (unsigned int i = 0; i < fVetoGroupNames.size(); i++) {
-        metadata << "Veto group " << fVetoGroupNames[i] << " signal IDs: " << fVetoGroupIds[i] << endl;
+        RESTMetadata << "Veto group " << fVetoGroupNames[i] << " signal IDs: " << fVetoGroupIds[i] << RESTendl;
     }
 
     if (fVetoSignalId[0] != -1) {
         for (unsigned int i = 0; i < fVetoSignalId.size(); i++) {
-            metadata << "Veto signal ID: " << fVetoSignalId[i] << endl;
+            RESTMetadata << "Veto signal ID: " << fVetoSignalId[i] << RESTendl;
         }
     } else {
-        metadata << " " << endl;
-        metadata << "All veto signal IDs: ";
+        RESTMetadata << " " << RESTendl;
+        RESTMetadata << "All veto signal IDs: ";
         for (unsigned int i = 0; i < fVetoGroupIds.size() - 1; i++) {
-            metadata << fVetoGroupIds[i] << ",";
+            RESTMetadata << fVetoGroupIds[i] << ",";
         }
-        metadata << fVetoGroupIds[fVetoGroupIds.size() - 1] << endl;
+        RESTMetadata << fVetoGroupIds[fVetoGroupIds.size() - 1] << RESTendl;
     }
     if (fThreshold != -1) {
-        metadata << "Veto threshold: " << fThreshold << endl;
+        RESTMetadata << "Veto threshold: " << fThreshold << RESTendl;
     }
     if (fTimeWindow[0] != -1) {
-        metadata << "Peak time window: (" << fTimeWindow[0] << ", " << fTimeWindow[1] << ")" << endl;
+        RESTMetadata << "Peak time window: (" << fTimeWindow[0] << ", " << fTimeWindow[1] << ")" << RESTendl;
     }
-    metadata << "Noise reduction: Points over Threshold parameters = (" << fPointThreshold << ", "
-             << fSignalThreshold << ", " << fPointsOverThreshold << ")" << endl;
+    RESTMetadata << "Noise reduction: Points over Threshold parameters = (" << fPointThreshold << ", "
+             << fSignalThreshold << ", " << fPointsOverThreshold << ")" << RESTendl;
 
     EndPrintProcess();
 }


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Large: 389](https://badgen.net/badge/PR%20Size/Large%3A%20389/red) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/RESTendl/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/RESTendl) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/RESTendl/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/RESTendl)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Related with https://github.com/rest-for-physics/framework/pull/225:
- Renamed custom `endl` to `RESTendl`
- Renamed other logger functions
  - `info` --> `RESTInfo`  
  - `debug` --> `RESTDebug`
  - `essential` --> `RESTEssential`
  - `warning` --> `RESTWarning`
  - `fout` --> `RESTcout`
  - `ferr` --> `RESTError`