### PR TITLE
Bug fix on TRestRawSignalChannelActivityProcess

### DIFF
--- a/src/TRestRawSignalChannelActivityProcess.cxx
+++ b/src/TRestRawSignalChannelActivityProcess.cxx
@@ -175,7 +175,7 @@ void TRestRawSignalChannelActivityProcess::InitProcess() {
 #ifdef REST_DetectorLib
     fReadout = GetMetadata<TRestDetectorReadout>();
 
-    debug << "TRestRawSignalChannelActivityProcess::InitProcess. Readout pointer : " << fReadout << endl;
+    RESTDebug << "TRestRawSignalChannelActivityProcess::InitProcess. Readout pointer : " << fReadout << RESTendl;
     if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Info && fReadout) fReadout->PrintMetadata();
 #endif
 


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 1](https://badgen.net/badge/PR%20Size/Ok%3A%201/green) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/juanangp-patch-1/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/juanangp-patch-1) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/juanangp-patch-1/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/juanangp-patch-1)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Bug fix.

Missing replacement of `RESTDebug` instead of `debug`