### PR TITLE
replaced dynamic length array initializaion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,10 @@
 set(LibraryVersion "1.6")
 add_definitions(-DLIBRARY_VERSION="${LibraryVersion}")
 
+if (CMAKE_SYSTEM_NAME MATCHES "Windows")
+    set(excludes TRestRawMemoryBufferToSignalProcess)
+endif (CMAKE_SYSTEM_NAME MATCHES "Windows")
+
 COMPILELIB("")
 
 file(GLOB_RECURSE MAC "${CMAKE_CURRENT_SOURCE_DIR}/macros/*")

--- a/inc/TRestRawFEUDreamToSignalProcess.h
+++ b/inc/TRestRawFEUDreamToSignalProcess.h
@@ -31,7 +31,11 @@
 #include <TROOT.h>
 #include <TSystem.h>
 #include <TTree.h>
+#ifndef WIN32
 #include <arpa/inet.h>
+#else
+#include <Winsock.h>
+#endif
 #include <signal.h>
 #include <stdint.h>
 #include <stdio.h>

--- a/src/TRestRawSignalConvolutionFittingProcess.cxx
+++ b/src/TRestRawSignalConvolutionFittingProcess.cxx
@@ -192,11 +192,11 @@ TRestEvent* TRestRawSignalConvolutionFittingProcess::ProcessEvent(TRestEvent* in
           << RESTendl;
 
     Double_t SigmaMean = 0;
-    Double_t Sigma[fRawSignalEvent->GetNumberOfSignals()];
+    vector<Double_t> Sigma(fRawSignalEvent->GetNumberOfSignals());
     Double_t RatioSigmaMaxPeakMean = 0;
-    Double_t RatioSigmaMaxPeak[fRawSignalEvent->GetNumberOfSignals()];
+    vector<Double_t> RatioSigmaMaxPeak(fRawSignalEvent->GetNumberOfSignals());
     Double_t ChiSquareMean = 0;
-    Double_t ChiSquare[fRawSignalEvent->GetNumberOfSignals()];
+    vector<Double_t> ChiSquare(fRawSignalEvent->GetNumberOfSignals());
 
     map<int, Double_t> amplitudeFit;
     map<int, Double_t> shapingtimeFit;

--- a/src/TRestRawSignalFittingProcess.cxx
+++ b/src/TRestRawSignalFittingProcess.cxx
@@ -180,11 +180,11 @@ TRestEvent* TRestRawSignalFittingProcess::ProcessEvent(TRestEvent* inputEvent) {
     RESTDebug << "TRestRawSignalFittingProcess::ProcessEvent. Event ID : " << fRawSignalEvent->GetID() << RESTendl;
 
     Double_t SigmaMean = 0;
-    Double_t Sigma[fRawSignalEvent->GetNumberOfSignals()];
+    vector<Double_t> Sigma(fRawSignalEvent->GetNumberOfSignals());
     Double_t RatioSigmaMaxPeakMean = 0;
-    Double_t RatioSigmaMaxPeak[fRawSignalEvent->GetNumberOfSignals()];
+    vector<Double_t> RatioSigmaMaxPeak(fRawSignalEvent->GetNumberOfSignals());
     Double_t ChiSquareMean = 0;
-    Double_t ChiSquare[fRawSignalEvent->GetNumberOfSignals()];
+    vector<Double_t> ChiSquare(fRawSignalEvent->GetNumberOfSignals());
 
     map<int, Double_t> baselineFit;
     map<int, Double_t> amplitudeFit;

--- a/src/TRestRawSignalGeneralFitProcess.cxx
+++ b/src/TRestRawSignalGeneralFitProcess.cxx
@@ -141,11 +141,11 @@ TRestEvent* TRestRawSignalGeneralFitProcess::ProcessEvent(TRestEvent* inputEvent
     RESTDebug << "TRestRawSignalGeneralFitProcess::ProcessEvent. Event ID : " << fRawSignalEvent->GetID() << RESTendl;
 
     Double_t SigmaMean = 0;
-    Double_t Sigma[fRawSignalEvent->GetNumberOfSignals()];
+    vector<Double_t> Sigma(fRawSignalEvent->GetNumberOfSignals());
     Double_t RatioSigmaMaxPeakMean = 0;
-    Double_t RatioSigmaMaxPeak[fRawSignalEvent->GetNumberOfSignals()];
+    vector<Double_t> RatioSigmaMaxPeak(fRawSignalEvent->GetNumberOfSignals());
     Double_t ChiSquareMean = 0;
-    Double_t ChiSquare[fRawSignalEvent->GetNumberOfSignals()];
+    vector<Double_t> ChiSquare(fRawSignalEvent->GetNumberOfSignals());
 
     /*map<int, Double_t> baselineFit;
     map<int, Double_t> amplitudeFit;

--- a/src/TRestRawSignalRecoverChannelsProcess.cxx
+++ b/src/TRestRawSignalRecoverChannelsProcess.cxx
@@ -187,7 +187,7 @@ TRestEvent* TRestRawSignalRecoverChannelsProcess::ProcessEvent(TRestEvent* evInp
         TRestRawSignal* recoveredSignal = new TRestRawSignal();
         recoveredSignal->SetID(fChannelIds[x]);
 
-        Short_t dataRecovered[nPoints];
+        vector<Short_t> dataRecovered(nPoints);
         for (int n = 0; n < nPoints; n++) dataRecovered[n] = 0;
 
         if (leftSgnl != nullptr) {


### PR DESCRIPTION
![nkx111](https://badgen.net/badge/PR%20submitted%20by%3A/nkx111/blue) ![Ok: 18](https://badgen.net/badge/PR%20Size/Ok%3A%2018/green) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/windows-compile/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/windows-compile) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/windows-compile/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/windows-compile)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Related to https://github.com/rest-for-physics/framework/pull/231. Array initialization with dynamic length is not available for msvc. Changed to vector. e.g. `Double_t x[nHits];` --> `vector<Double_t> x(nHits);`