### PR TITLE
TRestRawSignalRecoverChannelsProcess: removed #ifdef REST_DetectorLib…

### DIFF
--- a/inc/TRestRawSignalRecoverChannelsProcess.h
+++ b/inc/TRestRawSignalRecoverChannelsProcess.h
@@ -23,9 +23,9 @@
 #ifndef RestCore_TRestRawSignalRecoverChannelsProcess
 #define RestCore_TRestRawSignalRecoverChannelsProcess
 
-#ifdef REST_DetectorLib
+// #ifdef REST_DetectorLib
 #include <TRestDetectorReadout.h>
-#endif
+// #endif
 #include <TRestEventProcess.h>
 
 #include "TRestRawSignalEvent.h"
@@ -39,10 +39,8 @@ class TRestRawSignalRecoverChannelsProcess : public TRestEventProcess {
     /// A pointer to the specific TRestRawSignalEvent input
     TRestRawSignalEvent* fOutputSignalEvent;  //!
 
-#ifdef REST_DetectorLib
     /// A pointer to the readout previously defined inside REST.
     TRestDetectorReadout* fReadout;  //!
-#endif
 
     void Initialize() override;
 

--- a/src/TRestRawSignalRecoverChannelsProcess.cxx
+++ b/src/TRestRawSignalRecoverChannelsProcess.cxx
@@ -143,18 +143,18 @@ void TRestRawSignalRecoverChannelsProcess::LoadConfig(const string& configFilena
 /// TRestDetectorReadout.
 ///
 void TRestRawSignalRecoverChannelsProcess::InitProcess() {
-#ifdef REST_DetectorLib
+    // #ifdef REST_DetectorLib
     fReadout = GetMetadata<TRestDetectorReadout>();
 
     if (fReadout == nullptr) {
         cout << "REST ERROR: Readout has not been initialized" << endl;
         exit(-1);
     }
-#else
-    RESTError << "TRestRawSignalRecoverChannelsProcess will not be active." << RESTendl;
-    RESTError << "REST was not compiled with detectorlib" << RESTendl;
-    RESTError << "Please, remove this process or compile REST with detector library" << RESTendl;
-#endif
+    // #else
+    //     RESTError << "TRestRawSignalRecoverChannelsProcess will not be active." << RESTendl;
+    //     RESTError << "REST was not compiled with detectorlib" << RESTendl;
+    //     RESTError << "Please, remove this process or compile REST with detector library" << RESTendl;
+    // #endif
 }
 
 ///////////////////////////////////////////////
@@ -175,7 +175,8 @@ TRestEvent* TRestRawSignalRecoverChannelsProcess::ProcessEvent(TRestEvent* evInp
         // cout << "Channel id : " << fChannelIds[x] << " Left : " << idL << " Right
         // : " << idR << endl;
 
-        if( fOutputSignalEvent->GetSignalIndex(fChannelIds[x])> 0 ) fOutputSignalEvent->RemoveSignalWithId(fChannelIds[x]);
+        if (fOutputSignalEvent->GetSignalIndex(fChannelIds[x]) > 0)
+            fOutputSignalEvent->RemoveSignalWithId(fChannelIds[x]);
 
         if (idL == -1 || idR == -1) continue;
 
@@ -223,7 +224,7 @@ TRestEvent* TRestRawSignalRecoverChannelsProcess::ProcessEvent(TRestEvent* evInp
 
 void TRestRawSignalRecoverChannelsProcess::GetAdjacentSignalIds(Int_t signalId, Int_t& idLeft,
                                                                 Int_t& idRight) {
-#ifdef REST_DetectorLib
+    // #ifdef REST_DetectorLib
     for (int p = 0; p < fReadout->GetNumberOfReadoutPlanes(); p++) {
         TRestDetectorReadoutPlane* plane = fReadout->GetReadoutPlane(p);
         for (int m = 0; m < plane->GetNumberOfModules(); m++) {
@@ -242,7 +243,7 @@ void TRestRawSignalRecoverChannelsProcess::GetAdjacentSignalIds(Int_t signalId, 
             }
         }
     }
-#endif
+    // #endif
 
     idLeft = -1;
     idRight = -1;


### PR DESCRIPTION
![KonradAltenmueller](https://badgen.net/badge/PR%20submitted%20by%3A/KonradAltenmueller/blue) ![Ok: 12](https://badgen.net/badge/PR%20Size/Ok%3A%2012/green) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/RecoverChannels_update/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/RecoverChannels_update) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/RecoverChannels_update/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/RecoverChannels_update)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

I removed `#ifdef REST_DetectorLib` from the `TRestRawSignalRecoverChannelsProcess`, because it else wouldn't work (resulting in a crash when running the rml).

This would quickly solve #2