### PR TITLE
Adding new workflow to check if framework branch and PR exist

### DIFF
--- a/.github/workflows/submodulePR.yml
+++ b/.github/workflows/submodulePR.yml
@@ -1,0 +1,31 @@
+name: Check on framework PR
+
+on:
+  pull_request:
+    branches: [ "master" ]
+    types: [ "opened", "reopened", "created", "closed", "synchronize"]
+
+  workflow_dispatch:
+
+permissions: write-all
+
+env:
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  submodules-pr:
+    runs-on: ubuntu-latest
+    if: github.head_ref || github.ref_name != 'master'
+    steps:
+    - uses: actions/checkout@v3
+    #TODO change action branch
+    - name: Checkout submodules
+      uses: rest-for-physics/framework/.github/actions/automerge@auto-merge
+      with:
+        branch: ${{ env.BRANCH_NAME }}
+        repository: "rest-for-physics/framework"
+        token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Added new workflow for automatic merging of framework PR when a framework branch matches and a PR exist:
- Check if any framework branch matches current branch for merging
- In case a branch matches it check if a PR in the framework exist
- Workflow will fail in case a matching framework branch exist and there is no associated PR
- When the current PR is merged, the associated framework PR should be also merged
- Access tokens for the merge are needed (need to be discussed)

Contributes to https://github.com/rest-for-physics/framework/issues/250

Related to https://github.com/rest-for-physics/framework/pull/259