### PR TITLE
Adding function to read input parameters from the RML, and some renaming

### DIFF
--- a/inc/TRestRawSignalChannelActivityProcess.h
+++ b/inc/TRestRawSignalChannelActivityProcess.h
@@ -45,6 +45,8 @@ class TRestRawSignalChannelActivityProcess : public TRestEventProcess {
     TRestDetectorReadout* fReadout;  //!
 #endif
 
+    void InitFromConfigFile() override;
+
     void Initialize() override;
 
     void LoadDefaultConfig();
@@ -57,10 +59,10 @@ class TRestRawSignalChannelActivityProcess : public TRestEventProcess {
     Double_t fHighThreshold = 50;
 
     /// The number of bins at the daq channels histogram
-    Int_t fDaqChannels = 300;
+    Int_t fDaqHistogramChannels = 300;
 
     /// The number of bins at the readout channels histogram
-    Int_t fReadoutChannels = 128;
+    Int_t fReadoutHistogramChannels = 128;
 
     /// The first channel at the daq channels histogram
     Int_t fDaqStartChannel = 4320;
@@ -121,12 +123,12 @@ class TRestRawSignalChannelActivityProcess : public TRestEventProcess {
         RESTMetadata << "Low signal threshold activity : " << fLowThreshold << RESTendl;
         RESTMetadata << "High signal threshold activity : " << fHighThreshold << RESTendl;
 
-        RESTMetadata << "Number of daq histogram channels : " << fDaqChannels << RESTendl;
+        RESTMetadata << "Number of daq histogram channels : " << fDaqHistogramChannels << RESTendl;
         RESTMetadata << "Start daq channel : " << fDaqStartChannel << RESTendl;
         RESTMetadata << "End daq channel : " << fDaqEndChannel << RESTendl;
 
 #ifdef REST_DetectorLib
-        RESTMetadata << "Number of readout histogram channels : " << fReadoutChannels << RESTendl;
+        RESTMetadata << "Number of readout histogram channels : " << fReadoutHistogramChannels << RESTendl;
         RESTMetadata << "Start readout channel : " << fReadoutStartChannel << RESTendl;
         RESTMetadata << "End readout channel : " << fReadoutEndChannel << RESTendl;
 #else

--- a/inc/TRestRawSignalChannelActivityProcess.h
+++ b/inc/TRestRawSignalChannelActivityProcess.h
@@ -53,28 +53,28 @@ class TRestRawSignalChannelActivityProcess : public TRestEventProcess {
 
    protected:
     /// The value of the lower signal threshold to add it to the histogram
-    Double_t fLowThreshold = 25;
+    Double_t fLowThreshold;
 
     /// The value of the higher signal threshold to add it to the histogram
-    Double_t fHighThreshold = 50;
+    Double_t fHighThreshold;
 
     /// The number of bins at the daq channels histogram
-    Int_t fDaqHistogramChannels = 300;
+    Int_t fDaqHitsogramChannels;
 
     /// The number of bins at the readout channels histogram
-    Int_t fReadoutHistogramChannels = 128;
+    Int_t fReadoutHistogramChannels;
 
     /// The first channel at the daq channels histogram
-    Int_t fDaqStartChannel = 4320;
+    Int_t fDaqStartChannel;
 
     /// The last channel at the daq channels histogram
-    Int_t fDaqEndChannel = 4620;
+    Int_t fDaqEndChannel;
 
     /// The first channel at the readout channels histogram
-    Int_t fReadoutStartChannel = 0;
+    Int_t fReadoutStartChannel;
 
     /// The last channel at the readout channels histogram
-    Int_t fReadoutEndChannel = 128;
+    Int_t fReadoutEndChannel;
 
     /// The daq channels histogram
     TH1D* fDaqChannelsHisto;  //!

--- a/inc/TRestRawSignalChannelActivityProcess.h
+++ b/inc/TRestRawSignalChannelActivityProcess.h
@@ -59,7 +59,7 @@ class TRestRawSignalChannelActivityProcess : public TRestEventProcess {
     Double_t fHighThreshold;
 
     /// The number of bins at the daq channels histogram
-    Int_t fDaqHitsogramChannels;
+    Int_t fDaqHistogramChannels;
 
     /// The number of bins at the readout channels histogram
     Int_t fReadoutHistogramChannels;

--- a/src/TRestRawSignalChannelActivityProcess.cxx
+++ b/src/TRestRawSignalChannelActivityProcess.cxx
@@ -175,40 +175,43 @@ void TRestRawSignalChannelActivityProcess::InitProcess() {
 #ifdef REST_DetectorLib
     fReadout = GetMetadata<TRestDetectorReadout>();
 
-    RESTDebug << "TRestRawSignalChannelActivityProcess::InitProcess. Readout pointer : " << fReadout << RESTendl;
-    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Info && fReadout) fReadout->PrintMetadata();
+    RESTDebug << "TRestRawSignalChannelActivityProcess::InitProcess. Readout pointer : " << fReadout
+              << RESTendl;
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Info && fReadout)
+        fReadout->PrintMetadata();
 #endif
 
     if (!fReadOnly) {
-        fDaqChannelsHisto = new TH1D("daqChannelActivityRaw", "daqChannelActivityRaw", fDaqChannels,
+        fDaqChannelsHisto = new TH1D("daqChannelActivityRaw", "daqChannelActivityRaw", fDaqHistogramChannels,
                                      fDaqStartChannel, fDaqEndChannel);
 #ifdef REST_DetectorLib
         if (fReadout) {
-            fReadoutChannelsHisto = new TH1D("rChannelActivityRaw", "readoutChannelActivity",
-                                             fReadoutChannels, fReadoutStartChannel, fReadoutEndChannel);
+            fReadoutChannelsHisto =
+                new TH1D("rChannelActivityRaw", "readoutChannelActivity", fReadoutHistogramChannels,
+                         fReadoutStartChannel, fReadoutEndChannel);
             fReadoutChannelsHisto_OneSignal =
-                new TH1D("rChannelActivityRaw_1", "readoutChannelActivity", fReadoutChannels,
+                new TH1D("rChannelActivityRaw_1", "readoutChannelActivity", fReadoutHistogramChannels,
                          fReadoutStartChannel, fReadoutEndChannel);
             fReadoutChannelsHisto_OneSignal_High =
-                new TH1D("rChannelActivityRaw_1H", "readoutChannelActivity", fReadoutChannels,
+                new TH1D("rChannelActivityRaw_1H", "readoutChannelActivity", fReadoutHistogramChannels,
                          fReadoutStartChannel, fReadoutEndChannel);
             fReadoutChannelsHisto_TwoSignals =
-                new TH1D("rChannelActivityRaw_2", "readoutChannelActivity", fReadoutChannels,
+                new TH1D("rChannelActivityRaw_2", "readoutChannelActivity", fReadoutHistogramChannels,
                          fReadoutStartChannel, fReadoutEndChannel);
             fReadoutChannelsHisto_TwoSignals_High =
-                new TH1D("rChannelActivityRaw_2H", "readoutChannelActivity", fReadoutChannels,
+                new TH1D("rChannelActivityRaw_2H", "readoutChannelActivity", fReadoutHistogramChannels,
                          fReadoutStartChannel, fReadoutEndChannel);
             fReadoutChannelsHisto_ThreeSignals =
-                new TH1D("rChannelActivityRaw_3", "readoutChannelActivity", fReadoutChannels,
+                new TH1D("rChannelActivityRaw_3", "readoutChannelActivity", fReadoutHistogramChannels,
                          fReadoutStartChannel, fReadoutEndChannel);
             fReadoutChannelsHisto_ThreeSignals_High =
-                new TH1D("rChannelActivityRaw_3H", "readoutChannelActivity", fReadoutChannels,
+                new TH1D("rChannelActivityRaw_3H", "readoutChannelActivity", fReadoutHistogramChannels,
                          fReadoutStartChannel, fReadoutEndChannel);
             fReadoutChannelsHisto_MultiSignals =
-                new TH1D("rChannelActivityRaw_M", "readoutChannelActivity", fReadoutChannels,
+                new TH1D("rChannelActivityRaw_M", "readoutChannelActivity", fReadoutHistogramChannels,
                          fReadoutStartChannel, fReadoutEndChannel);
             fReadoutChannelsHisto_MultiSignals_High =
-                new TH1D("rChannelActivityRaw_MH", "readoutChannelActivity", fReadoutChannels,
+                new TH1D("rChannelActivityRaw_MH", "readoutChannelActivity", fReadoutHistogramChannels,
                          fReadoutStartChannel, fReadoutEndChannel);
         }
 #endif
@@ -263,7 +266,8 @@ TRestEvent* TRestRawSignalChannelActivityProcess::ProcessEvent(TRestEvent* input
         }
     }
 
-    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) fAnalysisTree->PrintObservables();
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
+        fAnalysisTree->PrintObservables();
 
     return fSignalEvent;
 }
@@ -292,4 +296,20 @@ void TRestRawSignalChannelActivityProcess::EndProcess() {
         }
 #endif
     }
+}
+
+///////////////////////////////////////////////
+/// \brief Function to read input parameters from the RML
+/// TRestRawSignalChannelActivityProcess metadata section
+///
+void TRestRawSignalChannelActivityProcess::InitFromConfigFile() {
+    fLowThreshold = StringToDouble(GetParameter("lowThreshold", "25"));
+    fHighThreshold = StringToDouble(GetParameter("highThreshold", "50"));
+
+    fDaqHistogramChannels = StringToInteger(GetParameter("daqChannels", "300"));
+    fDaqStartChannel = StringToInteger(GetParameter("daqStartCh", "4320"));
+    fDaqEndChannel = StringToInteger(GetParameter("daqEndCh", "4620"));
+    fReadoutHistogramChannels = StringToInteger(GetParameter("readoutChannels", "128"));
+    fReadoutStartChannel = StringToInteger(GetParameter("readoutStartCh", "0"));
+    fReadoutEndChannel = StringToInteger(GetParameter("readoutEndCh", "128"));
 }


### PR DESCRIPTION
![cmargalejo](https://badgen.net/badge/PR%20submitted%20by%3A/cmargalejo/blue) ![Ok: 46](https://badgen.net/badge/PR%20Size/Ok%3A%2046/green) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/rawChannelActivity/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/rawChannelActivity) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/rawChannelActivity/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/rawChannelActivity)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- Readout and DAQ number of channels to be used in the histograms can now be defined in the RML by the user.
- Some renaming to better match the names in `TRestDetectorSignalChannelActivityProcess`