### PR TITLE
TRestRawSignalChannelActivityProcess. Moving fReadout after data members

### DIFF
--- a/inc/TRestRawSignalChannelActivityProcess.h
+++ b/inc/TRestRawSignalChannelActivityProcess.h
@@ -40,16 +40,6 @@ class TRestRawSignalChannelActivityProcess : public TRestEventProcess {
     /// A pointer to the specific TRestRawSignalEvent input
     TRestRawSignalEvent* fSignalEvent;  //!
 
-#ifdef REST_DetectorLib
-    /// A pointer to the readout metadata information accessible to TRestRun
-    TRestDetectorReadout* fReadout;  //!
-#endif
-
-    void Initialize() override;
-
-    void LoadDefaultConfig();
-
-   protected:
     /// The value of the lower signal threshold to add it to the histogram
     Double_t fLowThreshold = 25;
 
@@ -103,6 +93,16 @@ class TRestRawSignalChannelActivityProcess : public TRestEventProcess {
 
     /// The readout channels histogram built more than 3-signal events (high threshold)
     TH1D* fReadoutChannelsHisto_MultiSignals_High;  //!
+
+#ifdef REST_DetectorLib
+    /// A pointer to the readout metadata information accessible to TRestRun
+    TRestDetectorReadout* fReadout;  //!
+#endif
+
+   protected:
+    void Initialize() override;
+
+    void LoadDefaultConfig();
 
    public:
     any GetInputEvent() const override { return fSignalEvent; }


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 10](https://badgen.net/badge/PR%20Size/Ok%3A%2010/green) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/jgalan_activity_fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/jgalan_activity_fix) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan_activity_fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan_activity_fix)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

There was a problem retrieving the metadata members of the process `TRestRawSignalChannelActivityProcess`. I found out that moving the `fReadout` pointer after the data members solves the problem.

I used the following RML definition for testing.

```
<xml>
    <TRestRawSignalChannelActivityProcess name="rawChActivity" value="ON" verboseLevel="info" >
        <parameter name="lowThreshold" value="25" />
        <parameter name="highThreshold" value="30" />
        <parameter name="daqHistogramChannels" value="360" />
        <parameter name="daqStartChannel" value="4320" />
        <parameter name="daqEndChannel" value="4360" />
        <parameter name="readoutHistogramChannels" value="250" />
        <parameter name="readoutStartChannel" value="0" />
        <parameter name="readoutEndChannel" value="250" />
    </TRestRawSignalChannelActivityProcess>
</xml>
```

The values before the fix were not correct, as shown here.

```
root [0] TRestRawSignalChannelActivityProcess t("test.rml")
(TRestRawSignalChannelActivityProcess &) Name: rawChActivity Title: Default TRestRawSignalChannelActivityProcess
root [1] t.PrintMetadata()

                                  ====================================================================================================                                     
                                  ||                         Process : TRestRawSignalChannelActivityProcess                         ||                                     
                                  ||  Name: rawChActivity  Title: Default TRestRawSignalChannelActivityProcess  VerboseLevel: info  ||                                     
                                  ||                        -----------------------------------------------                         ||                                     
                                  ||                                                                                                ||                                     
                                  ||                               Low signal threshold activity : 30                               ||                                     
                                  ||                              High signal threshold activity : 50                               ||                                     
                                  ||                            Number of daq histogram channels : 4320                             ||                                     
                                  ||                                     Start daq channel : 0                                      ||                                     
                                  ||                                     End daq channel : 250                                      ||                                     
                                  ||                          Number of readout histogram channels : 4360                           ||                                     
                                  ||                                   Start readout channel : 0                                    ||                                     
                                  ||                                   End readout channel : 128                                    ||                                     
                                  ||                                                                                                ||                                     
                                  ====================================================================================================                        
```

After moving the `fReadout` pointer one gets the right values.

```
root [0] TRestRawSignalChannelActivityProcess t("test.rml")
(TRestRawSignalChannelActivityProcess &) Name: rawChActivity Title: Default TRestRawSignalChannelActivityProcess
root [1] t.PrintMetadata()

                                  ====================================================================================================                                     
                                  ||                         Process : TRestRawSignalChannelActivityProcess                         ||                                     
                                  ||  Name: rawChActivity  Title: Default TRestRawSignalChannelActivityProcess  VerboseLevel: info  ||                                     
                                  ||                        -----------------------------------------------                         ||                                     
                                  ||                                                                                                ||                                     
                                  ||                               Low signal threshold activity : 25                               ||                                     
                                  ||                              High signal threshold activity : 30                               ||                                     
                                  ||                             Number of daq histogram channels : 300                             ||                                     
                                  ||                                    Start daq channel : 4320                                    ||                                     
                                  ||                                     End daq channel : 4360                                     ||                                     
                                  ||                           Number of readout histogram channels : 128                           ||                                     
                                  ||                                   Start readout channel : 0                                    ||                                     
                                  ||                                   End readout channel : 250                                    ||                                     
                                  ||                                                                                                ||                                     
                                  ====================================================================================================         
```                    

I am not sure why this problem is happening, I remember it happened before and we discussed a bit about it. But why the `fSignalEvent` pointer is not causing problem and `fReadout` it is? It would be good to understand the cause so that we can add a validation pipeline to prevent this behaviour. Probably @nkx knows the reason of this.