### PR TITLE
Good sig to id tagging

### DIFF
--- a/inc/TRestRawSignalIdTaggingProcess.h
+++ b/inc/TRestRawSignalIdTaggingProcess.h
@@ -77,6 +77,16 @@ class TRestRawSignalIdTaggingProcess : public TRestEventProcess {
             RESTMetadata << n + 1 << " - " << fTagNames[n] << ": ( " << fIdRanges[n].X() << ", "
                          << fIdRanges[n].Y() << " )" << RESTendl;
         }
+        
+        RESTMetadata << "Only good signals: " << fGoodSignalsOnly << RESTendl;
+        
+        if(fGoodSignalsOnly==true){
+            RESTMetadata << "Baseline range : ( " << fBaseLineRange.X() << " , " << fBaseLineRange.Y() << " ) "
+                     << RESTendl;
+            RESTMetadata << "Point Threshold : " << fPointThreshold << " sigmas" << RESTendl;
+            RESTMetadata << "Signal threshold : " << fSignalThreshold << " sigmas" << RESTendl;
+            RESTMetadata << "Number of points over threshold : " << fPointsOverThreshold << RESTendl;
+        }
         EndPrintProcess();
     }
 

--- a/inc/TRestRawSignalIdTaggingProcess.h
+++ b/inc/TRestRawSignalIdTaggingProcess.h
@@ -77,8 +77,8 @@ class TRestRawSignalIdTaggingProcess : public TRestEventProcess {
             RESTMetadata << n + 1 << " - " << fTagNames[n] << ": ( " << fIdRanges[n].X() << ", "
                          << fIdRanges[n].Y() << " )" << RESTendl;
         }
-        
-        RESTMetadata << "Only good signals: " << fGoodSignalsOnly << RESTendl;
+        RESTMetadata << " " << RESTendl;
+        RESTMetadata << "Only good signals: " << std::boolalpha << fGoodSignalsOnly << RESTendl;
         
         if(fGoodSignalsOnly==true){
             RESTMetadata << "Baseline range : ( " << fBaseLineRange.X() << " , " << fBaseLineRange.Y() << " ) "

--- a/inc/TRestRawSignalIdTaggingProcess.h
+++ b/inc/TRestRawSignalIdTaggingProcess.h
@@ -38,6 +38,23 @@ class TRestRawSignalIdTaggingProcess : public TRestEventProcess {
 
     /// A list containing the id range for each tag
     std::vector<TVector2> fIdRanges;
+    
+    //// Parameters to identify good signals ////
+    
+    /// The range where the baseline range will be calculated
+    TVector2 fBaseLineRange = TVector2(-1, -1);
+    
+    /// The number of sigmas over baseline fluctuations to identify a point overthreshold
+    Double_t fPointThreshold = -1;
+
+    /// A parameter to define a minimum signal fluctuation. Measured in sigmas.
+    Double_t fSignalThreshold = -1;
+
+    /// The minimum number of points over threshold to identify a signal as such
+    Int_t fPointsOverThreshold = -1;
+    
+    /// Properly initialized GoodSignals parameters (fBaseLineRange, fPointThreshold, fSignalThreshold, fPointsOverThreshold)
+    bool fGoodSignalsOnly = false;
 
     void Initialize() override;
     void InitFromConfigFile() override;

--- a/src/TRestRawSignalIdTaggingProcess.cxx
+++ b/src/TRestRawSignalIdTaggingProcess.cxx
@@ -65,6 +65,22 @@
 ///     * 1: Channels were found inside the `South` taq id range definition.
 ///     * 2: Channels were found inside the `North` taq id range definition.
 ///     * 12: Channels were found on both, `North` and `South` definitions.
+
+/// ### Good signal identification
+///
+/// Same parameters as in TRestRawSignalAnalisysProcess to identify good signals:
+///
+/// * **baseLineRange:** The bins from the rawdata samples that will be used
+/// to calculate the baseline average and fluctuation.
+/// * **pointThreshold**: The number of sigmas over baseline fluctuations to
+/// identify a point overthreshold
+/// * **signalThreshold**: A parameter to define a minimum signal fluctuation.
+/// Measured in sigmas.
+/// * **pointsOverThreshold**: The minimum number of points over threshold to
+/// identify a signal as such.
+///
+/// If any of these parameters is missing all signals will be taken into account
+/// to identify the ID range.
 ///
 /// ### Cuts
 ///
@@ -135,7 +151,13 @@ void TRestRawSignalIdTaggingProcess::InitFromConfigFile() {
     // This line is to exploit the retrieval of parameter as it is done at any process
     TRestEventProcess::InitFromConfigFile();
     
-    if (fPointThreshold!=-1 && fSignalThreshold!=-1 && fPointsOverThreshold!=-1 && fBaseLineRange.X()==-1 && fBaseLineRange.Y()==-1){fGoodSignalsOnly = true;}
+    RESTDebug << "fPointThreshold: " << fPointThreshold << RESTendl;
+    RESTDebug << "fSignalThreshold: " << fSignalThreshold << RESTendl;
+    RESTDebug << "fPointsOverThreshold: " << fPointsOverThreshold << RESTendl;
+    RESTDebug << "fBaseLineRange.X(): " << fBaseLineRange.X() << RESTendl;
+    RESTDebug << "fBaseLineRange.Y(): " << fBaseLineRange.Y() << RESTendl;
+    
+    if (fPointThreshold!=-1 && fSignalThreshold!=-1 && fPointsOverThreshold!=-1 && fBaseLineRange.X()!=-1 && fBaseLineRange.Y()!=-1){fGoodSignalsOnly = true;}
 
     // This is the additional code required by the process to read tags
     TiXmlElement* tagDefinition = GetElement("tag");


### PR DESCRIPTION
![DavidDiezIb](https://badgen.net/badge/PR%20submitted%20by%3A/DavidDiezIb/blue) ![Ok: 65](https://badgen.net/badge/PR%20Size/Ok%3A%2065/green) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/goodSigToIdTagging/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/goodSigToIdTagging) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/goodSigToIdTagging/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/goodSigToIdTagging)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Updated version to allow good signal identification. Now the tag of an event can be generated with all signals or only with signals identified as good ones. 
This is useful when you have channels that are always triggered, due to bad performance of the electronics or because all channes are being recorded.