### PR TITLE
TRestRawToSignalProcess. Properly adding runNumber and subRunNumber

### DIFF
--- a/inc/TRestRawToSignalProcess.h
+++ b/inc/TRestRawToSignalProcess.h
@@ -61,6 +61,11 @@ class TRestRawToSignalProcess : public TRestEventProcess {
     any GetInputEvent() const override { return any((TRestEvent*)nullptr); }
     any GetOutputEvent() const override { return fSignalEvent; }
 
+    virtual void InitProcess() override {
+        fRunOrigin = fRunInfo->GetRunNumber();
+        fSubRunOrigin = fRunInfo->GetSubRunNumber();
+    }
+
     void PrintMetadata() override;
     void Initialize() override;
     TRestMetadata* GetProcessMetadata() const { return nullptr; }

--- a/src/TRestRawMultiFEMINOSToSignalProcess.cxx
+++ b/src/TRestRawMultiFEMINOSToSignalProcess.cxx
@@ -218,6 +218,7 @@ void TRestRawMultiFEMINOSToSignalProcess::Initialize() {
 void TRestRawMultiFEMINOSToSignalProcess::InitProcess() {
     RESTDebug << "TRestRawMultiFeminos::InitProcess" << RESTendl;
     // Reading binary file header
+    TRestRawToSignalProcess::InitProcess();
 
     if (!fInputFileNames.empty() && TRestTools::GetFileNameExtension(fInputFileNames[0]) != "aqs") {
         RESTError << "The input file extension should be .aqs" << RESTendl;


### PR DESCRIPTION
Now TRestRawToSignalProcess properly adds the runNumber and subRunNumber extracted from TRestRun into each event.

Inheriting classes need to invoke `TRestRawToSignalProcess::InitProcess` to exploit this.