### PR TITLE
Added unistd.h for MacOS in TRestRawMemoryBufferToSignalProcess.cxx

### DIFF
--- a/src/TRestRawMemoryBufferToSignalProcess.cxx
+++ b/src/TRestRawMemoryBufferToSignalProcess.cxx
@@ -116,7 +116,6 @@ using namespace std;
 #include <unistd.h>
 #endif
 
-
 #if (defined(__GNU_LIBRARY__) && !defined(_SEM_SEMUN_UNDEFINED)) || __APPLE__
 // The union is already defined in sys/sem.h
 #else

--- a/src/TRestRawMemoryBufferToSignalProcess.cxx
+++ b/src/TRestRawMemoryBufferToSignalProcess.cxx
@@ -112,6 +112,11 @@ using namespace std;
 #include <sys/sem.h>
 #include <sys/shm.h>
 
+#ifdef __APPLE__
+#include <unistd.h>
+#endif
+
+
 #if (defined(__GNU_LIBRARY__) && !defined(_SEM_SEMUN_UNDEFINED)) || __APPLE__
 // The union is already defined in sys/sem.h
 #else


### PR DESCRIPTION
![heucheld](https://badgen.net/badge/PR%20submitted%20by%3A/heucheld/blue) ![Ok: 4](https://badgen.net/badge/PR%20Size/Ok%3A%204/green) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/heuchel_raw_macos_fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/heuchel_raw_macos_fix) [![](https://github.com/rest-for-physics/rawlib/actions/workflows/validation.yml/badge.svg?branch=heuchel_raw_macos_fix)](https://github.com/rest-for-physics/rawlib/commits/heuchel_raw_macos_fix)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Added simple include of <unistd.h> for MacOS in TRestRawMemoryBufferToSignalProcess.cxx.