### PR TITLE
Rounding AddPoint input

### DIFF
--- a/pipeline/processes/shaping/shaping.C
+++ b/pipeline/processes/shaping/shaping.C
@@ -53,23 +53,23 @@ Int_t shaping(Bool_t draw = false) {
         combinedEv->DrawEvent();
     }
 
-    if (gausMaxPeakPosition != 249) {
-        cout << "Problem on gaussian convolution! Position of the most intense peak should be 248!!" << endl;
+    if (gausMaxPeakPosition != 250) {
+        cout << "Problem on gaussian convolution! Position of the most intense peak should be 250!!" << endl;
         return 1;
     }
 
-    if (gausMaxPeakValue != 199) {
-        cout << "Problem on gaussian convolution! Ampltude of the most intense peak should be 124!!" << endl;
+    if (gausMaxPeakValue != 200) {
+        cout << "Problem on gaussian convolution! Amplitude of the most intense peak should be 200!!" << endl;
         return 2;
     }
 
-    if (agetMaxPeakPosition != 288) {
-        cout << "Problem on shaperSin convolution! Position of the most intense peak should be 287!!" << endl;
+    if (agetMaxPeakPosition != 289) {
+        cout << "Problem on shaperSin convolution! Position of the most intense peak should be 289!!" << endl;
         return 3;
     }
 
-    if (agetMaxPeakValue != 172) {
-        cout << "Problem on shaperSin convolution! Amplitude of the most intense peak should be 107!!"
+    if (agetMaxPeakValue != 173) {
+        cout << "Problem on shaperSin convolution! Amplitude of the most intense peak should be 173!!"
              << endl;
         return 4;
     }

--- a/src/TRestRawSignalShapingProcess.cxx
+++ b/src/TRestRawSignalShapingProcess.cxx
@@ -270,7 +270,7 @@ TRestEvent* TRestRawSignalShapingProcess::ProcessEvent(TRestEvent* inputEvent) {
         }
 
         for (int i = 0; i < nBins; i++) {
-            shapingSignal.AddPoint((Short_t)out[i]);
+            shapingSignal.AddPoint((Short_t)round(out[i]));
         }
         shapingSignal.SetSignalID(inSignal.GetSignalID());
 


### PR DESCRIPTION
![Andrii01L](https://badgen.net/badge/PR%20submitted%20by%3A/Andrii01L/blue) ![Ok: 9](https://badgen.net/badge/PR%20Size/Ok%3A%209/green) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/Andrii01L-patch-1/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/Andrii01L-patch-1) [![](https://github.com/rest-for-physics/rawlib/actions/workflows/validation.yml/badge.svg?branch=Andrii01L-patch-1)](https://github.com/rest-for-physics/rawlib/commits/Andrii01L-patch-1)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fixes # out[i] rounded when added to the output RawSignal in the RawSignalEvent

Pipeline requires rest-for-physics/framework#370