### PR TITLE
TRestRawSignalAnalysisProcess: added option to use robust baseline calculation

### DIFF
--- a/inc/TRestRawSignalAnalysisProcess.h
+++ b/inc/TRestRawSignalAnalysisProcess.h
@@ -42,6 +42,9 @@ class TRestRawSignalAnalysisProcess : public TRestEventProcess {
     /// The range where the observables will be calculated
     TVector2 fIntegralRange = TVector2(10, 500);
 
+    /// Option fo calculation of baseline parameters, can be set to "ROBUST"
+    std::string fBaseLineOption = "";
+
     /// The number of sigmas over baseline fluctuations to identify a point overthreshold
     Double_t fPointThreshold = 2;
 
@@ -76,6 +79,8 @@ class TRestRawSignalAnalysisProcess : public TRestEventProcess {
         RESTMetadata << "Point Threshold : " << fPointThreshold << " sigmas" << RESTendl;
         RESTMetadata << "Signal threshold : " << fSignalThreshold << " sigmas" << RESTendl;
         RESTMetadata << "Number of points over threshold : " << fPointsOverThreshold << RESTendl;
+        RESTMetadata << "Baseline calculation method: " << (fBaseLineOption.empty() ? "Standard" : "Robust")
+                     << RESTendl;
 
         EndPrintProcess();
     }

--- a/inc/TRestRawSignalAnalysisProcess.h
+++ b/inc/TRestRawSignalAnalysisProcess.h
@@ -42,7 +42,7 @@ class TRestRawSignalAnalysisProcess : public TRestEventProcess {
     /// The range where the observables will be calculated
     TVector2 fIntegralRange = TVector2(10, 500);
 
-    /// Option fo calculation of baseline parameters, can be set to "ROBUST"
+    /// Option for calculation of baseline parameters, can be set to "ROBUST"
     std::string fBaseLineOption = "";
 
     /// The number of sigmas over baseline fluctuations to identify a point overthreshold

--- a/inc/TRestRawSignalAnalysisProcess.h
+++ b/inc/TRestRawSignalAnalysisProcess.h
@@ -90,6 +90,6 @@ class TRestRawSignalAnalysisProcess : public TRestEventProcess {
     TRestRawSignalAnalysisProcess();   // Constructor
     ~TRestRawSignalAnalysisProcess();  // Destructor
 
-    ClassDefOverride(TRestRawSignalAnalysisProcess, 4);
+    ClassDefOverride(TRestRawSignalAnalysisProcess, 5);
 };
 #endif

--- a/src/TRestRawSignalAnalysisProcess.cxx
+++ b/src/TRestRawSignalAnalysisProcess.cxx
@@ -29,6 +29,12 @@
 /// the rawsignal analysis is performed:
 /// * **baseLineRange:** The bins from the rawdata samples that will be used
 /// to calculate the baseline average and fluctuation.
+///
+///	* **baseLineOption:** An optional parameter. When set to "ROBUST", the
+/// baseline parameters will be calculated using TRestRawSignal's robust
+///  methods, instead of mean and standard deviation, the median and IQR sigma
+/// are used.
+///
 /// * **integralRange**: The calculated observables will only consider points
 /// found inside this range.
 ///

--- a/src/TRestRawSignalAnalysisProcess.cxx
+++ b/src/TRestRawSignalAnalysisProcess.cxx
@@ -311,7 +311,7 @@ TRestEvent* TRestRawSignalAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) 
     /// raw-signals.
     // This will affect the calculation of observables, but not the stored
     // TRestRawSignal data.
-    fSignalEvent->SetBaseLineRange(fBaseLineRange);
+    fSignalEvent->SetBaseLineRange(fBaseLineRange, fBaseLineOption);
     fSignalEvent->SetRange(fIntegralRange);
 
     for (int s = 0; s < fSignalEvent->GetNumberOfSignals(); s++) {

--- a/src/TRestRawSignalAnalysisProcess.cxx
+++ b/src/TRestRawSignalAnalysisProcess.cxx
@@ -30,9 +30,9 @@
 /// * **baseLineRange:** The bins from the rawdata samples that will be used
 /// to calculate the baseline average and fluctuation.
 ///
-///	* **baseLineOption:** An optional parameter. When set to "ROBUST", the
+/// * **baseLineOption:** An optional parameter. When set to "ROBUST", the
 /// baseline parameters will be calculated using TRestRawSignal's robust
-///  methods, instead of mean and standard deviation, the median and IQR sigma
+/// methods, instead of mean and standard deviation, the median and IQR sigma
 /// are used.
 ///
 /// * **integralRange**: The calculated observables will only consider points


### PR DESCRIPTION
![KonradAltenmueller](https://badgen.net/badge/PR%20submitted%20by%3A/KonradAltenmueller/blue) ![Ok: 13](https://badgen.net/badge/PR%20Size/Ok%3A%2013/green) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/konrad_robustBaseLine/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/konrad_robustBaseLine) [![](https://github.com/rest-for-physics/rawlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=konrad_robustBaseLine)](https://github.com/rest-for-physics/rawlib/commits/konrad_robustBaseLine)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

In `TRestRawSignalAnalysisProcess` one can now use the option "ROBUST" for the base line calculation to obtain the median and IQR instead of mean and standard deviation.

To use it one has to add `<parameter name="baseLineOption" value="ROBUST" />` to `TRestRawSignalAnalysisProcess` in the rml.