### PR TITLE
Removal of custom typedef any since it is misleading with std::any

### DIFF
--- a/inc/TRestRawBaseLineCorrectionProcess.h
+++ b/inc/TRestRawBaseLineCorrectionProcess.h
@@ -44,8 +44,8 @@ class TRestRawBaseLineCorrectionProcess : public TRestEventProcess {
     Bool_t fRangeEnabled = false;  //!
 
    public:
-    any GetInputEvent() const override { return fInputEvent; }
-    any GetOutputEvent() const override { return fOutputEvent; }
+    RESTValue GetInputEvent() const override { return fInputEvent; }
+    RESTValue GetOutputEvent() const override { return fOutputEvent; }
 
     void InitProcess() override;
 

--- a/inc/TRestRawCommonNoiseReductionProcess.h
+++ b/inc/TRestRawCommonNoiseReductionProcess.h
@@ -58,8 +58,8 @@ class TRestRawCommonNoiseReductionProcess : public TRestEventProcess {
     // add here the members of your event process
 
    public:
-    any GetInputEvent() const override { return fInputEvent; }
-    any GetOutputEvent() const override { return fOutputEvent; }
+    RESTValue GetInputEvent() const override { return fInputEvent; }
+    RESTValue GetOutputEvent() const override { return fOutputEvent; }
 
     void InitProcess() override;
 

--- a/inc/TRestRawFindResponseSignalProcess.h
+++ b/inc/TRestRawFindResponseSignalProcess.h
@@ -41,8 +41,8 @@ class TRestRawFindResponseSignalProcess : public TRestEventProcess {
     // add here the members of your event process
 
    public:
-    any GetInputEvent() const override { return fInputSignalEvent; }
-    any GetOutputEvent() const override { return fOutputSignalEvent; }
+    RESTValue GetInputEvent() const override { return fInputSignalEvent; }
+    RESTValue GetOutputEvent() const override { return fOutputSignalEvent; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/inc/TRestRawMemoryBufferToSignalProcess.h
+++ b/inc/TRestRawMemoryBufferToSignalProcess.h
@@ -105,8 +105,8 @@ class TRestRawMemoryBufferToSignalProcess : public TRestEventProcess {
 
    protected:
    public:
-    any GetInputEvent() const override { return any((TRestEvent*)nullptr); }
-    any GetOutputEvent() const override { return fOutputRawSignalEvent; }
+    RESTValue GetInputEvent() const override { return RESTValue((TRestEvent*)nullptr); }
+    RESTValue GetOutputEvent() const override { return fOutputRawSignalEvent; }
 
     void InitProcess() override;
 

--- a/inc/TRestRawSignalAddNoiseProcess.h
+++ b/inc/TRestRawSignalAddNoiseProcess.h
@@ -51,10 +51,10 @@ class TRestRawSignalAddNoiseProcess : public TRestEventProcess {
     inline void SetNoiseLevel(Double_t noiseLevel) { fNoiseLevel = noiseLevel; }
 
     /// Returns a pointer to the input signal event
-    any GetInputEvent() const override { return fInputSignalEvent; }
+    RESTValue GetInputEvent() const override { return fInputSignalEvent; }
 
     /// Returns a pointer to the output signal event
-    any GetOutputEvent() const override { return fOutputSignalEvent; }
+    RESTValue GetOutputEvent() const override { return fOutputSignalEvent; }
 
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;
 

--- a/inc/TRestRawSignalAnalysisProcess.h
+++ b/inc/TRestRawSignalAnalysisProcess.h
@@ -63,8 +63,8 @@ class TRestRawSignalAnalysisProcess : public TRestEventProcess {
     // add here the members of your event process
 
    public:
-    any GetInputEvent() const override { return fSignalEvent; }
-    any GetOutputEvent() const override { return fSignalEvent; }
+    RESTValue GetInputEvent() const override { return fSignalEvent; }
+    RESTValue GetOutputEvent() const override { return fSignalEvent; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/inc/TRestRawSignalChannelActivityProcess.h
+++ b/inc/TRestRawSignalChannelActivityProcess.h
@@ -57,8 +57,8 @@ class TRestRawSignalChannelActivityProcess : public TRestEventProcess {
     void Initialize() override;
 
    public:
-    any GetInputEvent() const override { return fSignalEvent; }
-    any GetOutputEvent() const override { return fSignalEvent; }
+    RESTValue GetInputEvent() const override { return fSignalEvent; }
+    RESTValue GetOutputEvent() const override { return fSignalEvent; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/inc/TRestRawSignalConvolutionFittingProcess.h
+++ b/inc/TRestRawSignalConvolutionFittingProcess.h
@@ -53,8 +53,8 @@ class TRestRawSignalConvolutionFittingProcess : public TRestEventProcess {
     // add here the members of your event process
 
    public:
-    any GetInputEvent() const override { return fRawSignalEvent; }
-    any GetOutputEvent() const override { return fRawSignalEvent; }
+    RESTValue GetInputEvent() const override { return fRawSignalEvent; }
+    RESTValue GetOutputEvent() const override { return fRawSignalEvent; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/inc/TRestRawSignalFittingProcess.h
+++ b/inc/TRestRawSignalFittingProcess.h
@@ -49,8 +49,8 @@ class TRestRawSignalFittingProcess : public TRestEventProcess {
     // add here the members of your event process
 
    public:
-    any GetInputEvent() const override { return fRawSignalEvent; }
-    any GetOutputEvent() const override { return fRawSignalEvent; }
+    RESTValue GetInputEvent() const override { return fRawSignalEvent; }
+    RESTValue GetOutputEvent() const override { return fRawSignalEvent; }
 
     inline Double_t GetShaping() const { return fShaping; }
     inline Double_t GetStartPosition() const { return fStartPosition; }

--- a/inc/TRestRawSignalGeneralFitProcess.h
+++ b/inc/TRestRawSignalGeneralFitProcess.h
@@ -54,8 +54,8 @@ class TRestRawSignalGeneralFitProcess : public TRestEventProcess {
     // add here the members of your event process
 
    public:
-    any GetInputEvent() const override { return fRawSignalEvent; }
-    any GetOutputEvent() const override { return fRawSignalEvent; }
+    RESTValue GetInputEvent() const override { return fRawSignalEvent; }
+    RESTValue GetOutputEvent() const override { return fRawSignalEvent; }
 
     TF1* GetFunction() { return fFitFunc; }
 

--- a/inc/TRestRawSignalIdTaggingProcess.h
+++ b/inc/TRestRawSignalIdTaggingProcess.h
@@ -64,8 +64,8 @@ class TRestRawSignalIdTaggingProcess : public TRestEventProcess {
     // add here the members of your event process
 
    public:
-    any GetInputEvent() const override { return fSignalEvent; }
-    any GetOutputEvent() const override { return fSignalEvent; }
+    RESTValue GetInputEvent() const override { return fSignalEvent; }
+    RESTValue GetOutputEvent() const override { return fSignalEvent; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/inc/TRestRawSignalRangeReductionProcess.h
+++ b/inc/TRestRawSignalRangeReductionProcess.h
@@ -53,8 +53,8 @@ class TRestRawSignalRangeReductionProcess : public TRestEventProcess {
     inline TVector2 GetDigitizationInputRange() const { return fDigitizationInputRange; }
     void SetDigitizationInputRange(const TVector2& range);
 
-    any GetInputEvent() const override { return fInputRawSignalEvent; }
-    any GetOutputEvent() const override { return fOutputRawSignalEvent; }
+    RESTValue GetInputEvent() const override { return fInputRawSignalEvent; }
+    RESTValue GetOutputEvent() const override { return fOutputRawSignalEvent; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/inc/TRestRawSignalRemoveChannelsProcess.h
+++ b/inc/TRestRawSignalRemoveChannelsProcess.h
@@ -50,8 +50,8 @@ class TRestRawSignalRemoveChannelsProcess : public TRestEventProcess {
     TVector2 fSignalRange = TVector2(-1, -1);
 
    public:
-    any GetInputEvent() const override { return fInputSignalEvent; }
-    any GetOutputEvent() const override { return fOutputSignalEvent; }
+    RESTValue GetInputEvent() const override { return fInputSignalEvent; }
+    RESTValue GetOutputEvent() const override { return fOutputSignalEvent; }
 
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;
 

--- a/inc/TRestRawSignalShapingProcess.h
+++ b/inc/TRestRawSignalShapingProcess.h
@@ -60,8 +60,8 @@ class TRestRawSignalShapingProcess : public TRestEventProcess {
     inline Double_t GetShapingGain() const { return fShapingGain; }
     inline void SetShapingGain(Double_t shapingGain) { fShapingGain = shapingGain; }
 
-    any GetInputEvent() const override { return fInputSignalEvent; }
-    any GetOutputEvent() const override { return fOutputSignalEvent; }
+    RESTValue GetInputEvent() const override { return fInputSignalEvent; }
+    RESTValue GetOutputEvent() const override { return fOutputSignalEvent; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/inc/TRestRawSignalViewerProcess.h
+++ b/inc/TRestRawSignalViewerProcess.h
@@ -53,8 +53,8 @@ class TRestRawSignalViewerProcess : public TRestEventProcess {
     // add here the members of your event process
 
    public:
-    any GetInputEvent() const override { return fSignalEvent; }
-    any GetOutputEvent() const override { return fSignalEvent; }
+    RESTValue GetInputEvent() const override { return fSignalEvent; }
+    RESTValue GetOutputEvent() const override { return fSignalEvent; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/inc/TRestRawToSignalProcess.h
+++ b/inc/TRestRawToSignalProcess.h
@@ -58,8 +58,8 @@ class TRestRawToSignalProcess : public TRestEventProcess {
     void LoadDefaultConfig();
 
    public:
-    any GetInputEvent() const override { return any((TRestEvent*)nullptr); }
-    any GetOutputEvent() const override { return fSignalEvent; }
+    RESTValue GetInputEvent() const override { return RESTValue((TRestEvent*)nullptr); }
+    RESTValue GetOutputEvent() const override { return fSignalEvent; }
 
     virtual void InitProcess() override {
         fRunOrigin = fRunInfo->GetRunNumber();

--- a/inc/TRestRawVetoAnalysisProcess.h
+++ b/inc/TRestRawVetoAnalysisProcess.h
@@ -74,8 +74,8 @@ class TRestRawVetoAnalysisProcess : public TRestEventProcess {
 
    protected:
    public:
-    any GetInputEvent() const override { return fSignalEvent; }
-    any GetOutputEvent() const override { return fSignalEvent; }
+    RESTValue GetInputEvent() const override { return fSignalEvent; }
+    RESTValue GetOutputEvent() const override { return fSignalEvent; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/macros/REST_Raw_PlotVetoData.C
+++ b/macros/REST_Raw_PlotVetoData.C
@@ -158,7 +158,7 @@ Int_t REST_Raw_PlotVetoData(
             obsID = aTree->GetObservableID(obsNameTime[i]);
             peakTimeMap.clear();
 
-            any a = aTree->GetObservable(obsID);
+            auto a = aTree->GetObservable(obsID);
 
             a >> peakTimeMap;
 


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 35](https://badgen.net/badge/PR%20Size/Ok%3A%2035/green) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/any_to_RESTValue/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/any_to_RESTValue) [![](https://github.com/rest-for-physics/rawlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=any_to_RESTValue)](https://github.com/rest-for-physics/rawlib/commits/any_to_RESTValue) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Removal of custom `typedef REST_Reflection::TRestReflector any` since it is misleading with `std::any`.

The custom typedef `any` has been replaced by existing `typedef REST_Reflection::TRestReflector RESTValue`

Related PR https://github.com/rest-for-physics/framework/pull/471