### PR TITLE
Jporron filter type baseline correction

### DIFF
--- a/inc/TRestRawBaseLineCorrectionProcess.h
+++ b/inc/TRestRawBaseLineCorrectionProcess.h
@@ -25,30 +25,30 @@
 
 #include <TRestEventProcess.h>
 
-#include "TRestRawSignalEvent.h"
 #include "TRestRawReadoutMetadata.h"
+#include "TRestRawSignalEvent.h"
 
 using namespace std;
 
 class TRestRawBaseLineCorrectionProcess : public TRestEventProcess {
    private:
     // We define specific input/output event data holders
-    TRestRawSignalEvent* fInputEvent;   //!        
+    TRestRawSignalEvent* fInputEvent;   //!
     TRestRawSignalEvent* fOutputEvent;  //!
-	TRestRawReadoutMetadata* fReadoutMetadata = nullptr; 
+    TRestRawReadoutMetadata* fReadoutMetadata = nullptr;
 
     void Initialize() override;
 
     /// It defines the signals id range where analysis is applied
-	TVector2 fSignalsRange = {-1, -1};
+    TVector2 fSignalsRange = {-1, -1};
 
     /// Time window width in bins for the moving average filter for baseline correction
-	UShort_t fSmoothingWindow = 75;
+    UShort_t fSmoothingWindow = 75;
 
     /// Just a flag to quickly determine if we have to apply the range filter
     Bool_t fRangeEnabled = false;  //!
 
-	/// Maps defined later
+    /// Maps defined later
 
    public:
     RESTValue GetInputEvent() const override { return fInputEvent; }
@@ -60,30 +60,32 @@ class TRestRawBaseLineCorrectionProcess : public TRestEventProcess {
 
     void EndProcess() override;
 
-	void InitFromConfigFile() override;
+    void InitFromConfigFile() override;
 
-	struct Parameters {
+    struct Parameters {
         Double_t smoothingWindow = 75.0;
         TVector2 signalsRange = {-1, -1};
     };
 
-	void PrintMetadata() override {
-		BeginPrintProcess();
+    void PrintMetadata() override {
+        BeginPrintProcess();
 
-		for (const auto& channelType : fChannelTypes) {
-        	RESTMetadata << RESTendl;
-        	string type = channelType;
-        	if (type.empty()) {
-            	RESTMetadata << "No channel type specified. All types will be processed." << RESTendl;
-        	}
-        	RESTMetadata << "Readout type: " << type << RESTendl;
-			RESTMetadata << "Smoothing window size: " << fParametersMap.at(channelType).smoothingWindow << RESTendl;
-        	RESTMetadata << "Baseline correction applied to signals with IDs in range (" << fParametersMap.at(channelType).signalsRange.X()
-		             << "," << fParametersMap.at(channelType).signalsRange.Y() << ")" << RESTendl;
-		}
+        for (const auto& channelType : fChannelTypes) {
+            RESTMetadata << RESTendl;
+            string type = channelType;
+            if (type.empty()) {
+                RESTMetadata << "No channel type specified. All types will be processed." << RESTendl;
+            }
+            RESTMetadata << "Readout type: " << type << RESTendl;
+            RESTMetadata << "Smoothing window size: " << fParametersMap.at(channelType).smoothingWindow
+                         << RESTendl;
+            RESTMetadata << "Baseline correction applied to signals with IDs in range ("
+                         << fParametersMap.at(channelType).signalsRange.X() << ","
+                         << fParametersMap.at(channelType).signalsRange.Y() << ")" << RESTendl;
+        }
 
-		EndPrintProcess();
-	}
+        EndPrintProcess();
+    }
 
     /// Returns a new instance of this class
     TRestEventProcess* Maker() { return new TRestRawBaseLineCorrectionProcess; }
@@ -98,9 +100,9 @@ class TRestRawBaseLineCorrectionProcess : public TRestEventProcess {
     // you add/rename/remove the process parameters
     ClassDefOverride(TRestRawBaseLineCorrectionProcess, 1);
 
-	private:
-	/// Specify the channel types we want the process to be applied for
-	std::set<std::string> fChannelTypes;
-	std::map<std::string, Parameters> fParametersMap;
+   private:
+    /// Specify the channel types we want the process to be applied for
+    std::set<std::string> fChannelTypes;
+    std::map<std::string, Parameters> fParametersMap;
 };
 #endif

--- a/src/TRestRawBaseLineCorrectionProcess.cxx
+++ b/src/TRestRawBaseLineCorrectionProcess.cxx
@@ -85,12 +85,12 @@ TRestRawBaseLineCorrectionProcess::~TRestRawBaseLineCorrectionProcess() {
 
 TRestEvent* TRestRawBaseLineCorrectionProcess::ProcessEvent(TRestEvent* evInput) {
     fInputEvent = dynamic_cast<TRestRawSignalEvent*>(evInput);
-	fInputEvent->InitializeReferences(GetRunInfo());
+    fInputEvent->InitializeReferences(GetRunInfo());
 
-	if (fReadoutMetadata == nullptr) {
+    if (fReadoutMetadata == nullptr) {
         fReadoutMetadata = fInputEvent->GetReadoutMetadata();
     }
- 
+
     if (fReadoutMetadata == nullptr) {
         std::cerr << "TRestRawBaseLineCorrectionProcess::ProcessEvent: readout metadata is null" << std::endl;
         exit(1);
@@ -100,10 +100,10 @@ TRestEvent* TRestRawBaseLineCorrectionProcess::ProcessEvent(TRestEvent* evInput)
         TRestRawSignal* sgnl = fInputEvent->GetSignal(s);
 
         const UShort_t signalId = sgnl->GetSignalID();
- 
+
         const std::string channelType = fReadoutMetadata->GetTypeForChannelDaqId(signalId);
         const std::string channelName = fReadoutMetadata->GetNameForChannelDaqId(signalId);
- 
+
         // check if channel type is in the list of selected channel types
         if (fChannelTypes.find(channelType) == fChannelTypes.end()) {
             continue;
@@ -126,19 +126,18 @@ TRestEvent* TRestRawBaseLineCorrectionProcess::ProcessEvent(TRestEvent* evInput)
 void TRestRawBaseLineCorrectionProcess::InitProcess() {
     if (fSignalsRange.X() != -1 && fSignalsRange.Y() != -1) fRangeEnabled = true;
 
-	const auto filterType = GetParameter("channelType", "");
+    const auto filterType = GetParameter("channelType", "");
     if (!filterType.empty()) {
         fChannelTypes.insert(filterType);
-		std::cout << "Types: " << filterType << std::endl;
+        std::cout << "Types: " << filterType << std::endl;
     }
- 
+
     if (fChannelTypes.empty()) {
         // if no channel type is specified, use all channel types
     }
 }
 
 void TRestRawBaseLineCorrectionProcess::EndProcess() {}
-
 
 void TRestRawBaseLineCorrectionProcess::Initialize() {
     SetSectionName(this->ClassName());
@@ -147,7 +146,7 @@ void TRestRawBaseLineCorrectionProcess::Initialize() {
 }
 
 void TRestRawBaseLineCorrectionProcess::InitFromConfigFile() {
-	TString channelTypesString = GetParameter("channelTypes", "");
+    TString channelTypesString = GetParameter("channelTypes", "");
     // split it by ","
     TObjArray* channelTypesArray = channelTypesString.Tokenize(",");
     for (int i = 0; i < channelTypesArray->GetEntries(); i++) {
@@ -162,16 +161,16 @@ void TRestRawBaseLineCorrectionProcess::InitFromConfigFile() {
     for (const auto& type : fChannelTypes) {
         fChannelTypes.insert(type);
         fParametersMap[type] = {};
- 
+
         string typeCamelCase = type;
         typeCamelCase[0] = toupper(typeCamelCase[0]);
- 
+
         Parameters parameters;
-        parameters.smoothingWindow = GetDblParameterWithUnits("smoothingWindow" + typeCamelCase, parameters.smoothingWindow);
+        parameters.smoothingWindow =
+            GetDblParameterWithUnits("smoothingWindow" + typeCamelCase, parameters.smoothingWindow);
         parameters.signalsRange =
             Get2DVectorParameterWithUnits("signalsRange" + typeCamelCase, parameters.signalsRange);
         ;
         fParametersMap[type] = parameters;
     }
-
 }


### PR DESCRIPTION
![JPorron](https://badgen.net/badge/PR%20submitted%20by%3A/JPorron/blue) ![Medium: 110](https://badgen.net/badge/PR%20Size/Medium%3A%20110/orange) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/jporron-filter-type-baseline-correction/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/jporron-filter-type-baseline-correction) [![](https://github.com/rest-for-physics/rawlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=jporron-filter-type-baseline-correction)](https://github.com/rest-for-physics/rawlib/commits/jporron-filter-type-baseline-correction) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The process is modified to allow for it to be applied to different signal types, with different parameters.

The logic in the .rml file is:

        <addProcess type="TRestRawBaseLineCorrectionProcess" name="blCorrection" value="ON" verboseLevel="info">
			<parameter name="channelTypes" value="tpc,veto"/>
            <parameter name="signalsRangeTpc" value="(4610,4900)"/>
            <parameter name="smoothingWindowTpc" value="75"/>
        </addProcess>

The channel types are separated by a , and the new parameters add at the end the channel type they are applied for. If we wanted to add different parameters for veto type signals:  

        <addProcess type="TRestRawBaseLineCorrectionProcess" name="blCorrection" value="ON" verboseLevel="info">
			<parameter name="channelTypes" value="tpc,veto"/>
            <parameter name="signalsRangeTpc" value="(4610,4900)"/>
            <parameter name="smoothingWindowTpc" value="75"/>
            <parameter name="signalsRangeVeto" value="(4810,4950)"/>
        </addProcess>

If not specified the default values are 75 for the smoothing window and (-1, -1) for the signals range.