### PR TITLE
Use readout instead of signal ids

### DIFF
--- a/inc/TRestRawCommonNoiseReductionProcess.h
+++ b/inc/TRestRawCommonNoiseReductionProcess.h
@@ -103,6 +103,6 @@ class TRestRawCommonNoiseReductionProcess : public TRestEventProcess {
     // Destructor
     ~TRestRawCommonNoiseReductionProcess();
 
-    ClassDefOverride(TRestRawCommonNoiseReductionProcess, 2);
+    ClassDefOverride(TRestRawCommonNoiseReductionProcess, 3);
 };
 #endif

--- a/inc/TRestRawCommonNoiseReductionProcess.h
+++ b/inc/TRestRawCommonNoiseReductionProcess.h
@@ -23,9 +23,9 @@
 #ifndef RestCore_TRestRawCommonNoiseReductionProcess
 #define RestCore_TRestRawCommonNoiseReductionProcess
 
+#include <TRestEventProcess.h>
 #include <TRestRawSignalEvent.h>
 
-#include "TRestEventProcess.h"
 #include "TRestRawSignal.h"
 
 //! A process to subtract the common channels noise from RawSignal type
@@ -50,12 +50,12 @@ class TRestRawCommonNoiseReductionProcess : public TRestEventProcess {
     /// Minimum number of signals required to apply the process.
     Int_t fMinSignalsRequired = 200;
 
+    std::string fChannelType;
+    TRestRawReadoutMetadata* fReadoutMetadata = nullptr;  //!
+
     void Initialize() override;
 
     void LoadDefaultConfig();
-
-   protected:
-    // add here the members of your event process
 
    public:
     RESTValue GetInputEvent() const override { return fInputEvent; }
@@ -72,9 +72,17 @@ class TRestRawCommonNoiseReductionProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
+        if (!fChannelType.empty()) {
+            RESTMetadata << "channelType : " << fChannelType << RESTendl;
+        }
+
         RESTMetadata << " mode : [" << fMode << "]";
-        if (fMode == 0) RESTMetadata << " --> Mode 0 activated." << RESTendl;
-        if (fMode == 1) RESTMetadata << " --> Mode 1 activated." << RESTendl;
+        if (fMode == 0) {
+            RESTMetadata << " --> Mode 0 activated." << RESTendl;
+        }
+        if (fMode == 1) {
+            RESTMetadata << " --> Mode 1 activated." << RESTendl;
+        }
         RESTMetadata << " centerWidth : " << fCenterWidth << RESTendl;
         RESTMetadata << "blocks : [" << fBlocks << "]" << RESTendl;
         RESTMetadata << " Minimum number of signals : " << fMinSignalsRequired << RESTendl;

--- a/inc/TRestRawSignalChannelActivityProcess.h
+++ b/inc/TRestRawSignalChannelActivityProcess.h
@@ -87,6 +87,6 @@ class TRestRawSignalChannelActivityProcess : public TRestEventProcess {
     TRestRawSignalChannelActivityProcess();
     ~TRestRawSignalChannelActivityProcess();
 
-    ClassDefOverride(TRestRawSignalChannelActivityProcess, 4);
+    ClassDefOverride(TRestRawSignalChannelActivityProcess, 5);
 };
 #endif

--- a/inc/TRestRawSignalChannelActivityProcess.h
+++ b/inc/TRestRawSignalChannelActivityProcess.h
@@ -71,6 +71,10 @@ class TRestRawSignalChannelActivityProcess : public TRestEventProcess {
     void PrintMetadata() override {
         BeginPrintProcess();
 
+        if (!fChannelType.empty()) {
+            RESTMetadata << "channelType : " << fChannelType << RESTendl;
+        }
+
         RESTMetadata << "Low signal threshold activity : " << fLowThreshold << RESTendl;
         RESTMetadata << "High signal threshold activity : " << fHighThreshold << RESTendl;
 

--- a/inc/TRestRawSignalChannelActivityProcess.h
+++ b/inc/TRestRawSignalChannelActivityProcess.h
@@ -24,9 +24,9 @@
 #define RestCore_TRestRawSignalChannelActivityProcess
 
 #include <TH1D.h>
-#include <TRestRawSignalEvent.h>
+#include <TRestEventProcess.h>
 
-#include "TRestEventProcess.h"
+#include "TRestRawSignalEvent.h"
 
 //! A pure analysis process to generate histograms with detector channels
 //! activity
@@ -53,6 +53,9 @@ class TRestRawSignalChannelActivityProcess : public TRestEventProcess {
    private:
     /// A pointer to the specific TRestRawSignalEvent input
     TRestRawSignalEvent* fSignalEvent = nullptr;  //!
+
+    std::string fChannelType;
+    TRestRawReadoutMetadata* fReadoutMetadata = nullptr;  //!
 
     void Initialize() override;
 

--- a/inc/TRestRawVetoAnalysisProcess.h
+++ b/inc/TRestRawVetoAnalysisProcess.h
@@ -66,6 +66,8 @@ class TRestRawVetoAnalysisProcess : public TRestEventProcess {
     Double_t fSignalThreshold;
     Int_t fPointsOverThreshold;
 
+    TRestRawReadoutMetadata* fReadoutMetadata = nullptr;  //!
+
     void InitFromConfigFile() override;
 
     void Initialize() override;
@@ -105,8 +107,8 @@ class TRestRawVetoAnalysisProcess : public TRestEventProcess {
         return output;
     }
 
-    Int_t GetGroupIndex(std::string groupName);
-    std::string GetGroupIds(std::string groupName);
+    Int_t GetGroupIndex(const std::string& groupName);
+    std::string GetGroupIds(const std::string& groupName);
 
     TRestRawVetoAnalysisProcess();
     TRestRawVetoAnalysisProcess(const char* configFilename);

--- a/src/TRestRawBaseLineCorrectionProcess.cxx
+++ b/src/TRestRawBaseLineCorrectionProcess.cxx
@@ -90,7 +90,11 @@ void TRestRawBaseLineCorrectionProcess::Initialize() {
 
 TRestEvent* TRestRawBaseLineCorrectionProcess::ProcessEvent(TRestEvent* evInput) {
     fInputEvent = dynamic_cast<TRestRawSignalEvent*>(evInput);
-    fInputEvent->InitializeReferences(GetRunInfo());
+
+    const auto run = GetRunInfo();
+    if (run != nullptr) {
+        fInputEvent->InitializeReferences(run);
+    }
 
     if (fReadoutMetadata == nullptr) {
         fReadoutMetadata = fInputEvent->GetReadoutMetadata();

--- a/src/TRestRawCommonNoiseReductionProcess.cxx
+++ b/src/TRestRawCommonNoiseReductionProcess.cxx
@@ -174,7 +174,7 @@ TRestEvent* TRestRawCommonNoiseReductionProcess::ProcessEvent(TRestEvent* inputE
 
     const auto run = GetRunInfo();
     if (run != nullptr) {
-        fInputEvent->InitializeReferences(GetRunInfo());
+        fInputEvent->InitializeReferences(run);
     }
 
     if (fInputEvent->GetNumberOfSignals() < fMinSignalsRequired) {

--- a/src/TRestRawCommonNoiseReductionProcess.cxx
+++ b/src/TRestRawCommonNoiseReductionProcess.cxx
@@ -171,7 +171,11 @@ void TRestRawCommonNoiseReductionProcess::InitProcess() {}
 ///
 TRestEvent* TRestRawCommonNoiseReductionProcess::ProcessEvent(TRestEvent* inputEvent) {
     fInputEvent = (TRestRawSignalEvent*)inputEvent;
-    fInputEvent->InitializeReferences(GetRunInfo());
+
+    const auto run = GetRunInfo();
+    if (run != nullptr) {
+        fInputEvent->InitializeReferences(GetRunInfo());
+    }
 
     if (fInputEvent->GetNumberOfSignals() < fMinSignalsRequired) {
         for (int signal = 0; signal < fInputEvent->GetNumberOfSignals(); signal++) {

--- a/src/TRestRawCommonNoiseReductionProcess.cxx
+++ b/src/TRestRawCommonNoiseReductionProcess.cxx
@@ -170,7 +170,7 @@ void TRestRawCommonNoiseReductionProcess::InitProcess() {}
 /// \brief The main processing event function
 ///
 TRestEvent* TRestRawCommonNoiseReductionProcess::ProcessEvent(TRestEvent* inputEvent) {
-    fInputEvent = (TRestRawSignalEvent*)inputEvent;
+    fInputEvent = dynamic_cast<TRestRawSignalEvent*>(inputEvent);
 
     const auto run = GetRunInfo();
     if (run != nullptr) {

--- a/src/TRestRawCommonNoiseReductionProcess.cxx
+++ b/src/TRestRawCommonNoiseReductionProcess.cxx
@@ -171,6 +171,7 @@ void TRestRawCommonNoiseReductionProcess::InitProcess() {}
 ///
 TRestEvent* TRestRawCommonNoiseReductionProcess::ProcessEvent(TRestEvent* inputEvent) {
     fInputEvent = (TRestRawSignalEvent*)inputEvent;
+    fInputEvent->InitializeReferences(GetRunInfo());
 
     if (fInputEvent->GetNumberOfSignals() < fMinSignalsRequired) {
         for (int signal = 0; signal < fInputEvent->GetNumberOfSignals(); signal++) {

--- a/src/TRestRawPeaksFinderProcess.cxx
+++ b/src/TRestRawPeaksFinderProcess.cxx
@@ -11,7 +11,11 @@ void TRestRawPeaksFinderProcess::InitProcess() {}
 
 TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
     fSignalEvent = dynamic_cast<TRestRawSignalEvent*>(inputEvent);
-    fSignalEvent->InitializeReferences(GetRunInfo());
+    const auto run = GetRunInfo();
+    if (run != nullptr) {
+        fSignalEvent->InitializeReferences(run);
+    }
+
     auto event = fSignalEvent->GetSignalEventForTypes(fChannelTypes, fReadoutMetadata);
 
     if (fReadoutMetadata == nullptr) {

--- a/src/TRestRawPeaksFinderProcess.cxx
+++ b/src/TRestRawPeaksFinderProcess.cxx
@@ -175,15 +175,15 @@ void TRestRawPeaksFinderProcess::InitFromConfigFile() {
 }
 
 void TRestRawPeaksFinderProcess::PrintMetadata() {
-    cout << "Applying process to channel types: ";
+    RESTMetadata << "Applying process to channel types: ";
     for (const auto& type : fChannelTypes) {
-        cout << type << " ";
+        RESTMetadata << type << " ";
     }
-    cout << endl;
+    RESTMetadata << RESTendl;
 
-    cout << "Threshold over baseline: " << fThresholdOverBaseline << endl;
-    cout << "Baseline range: " << fBaselineRange.X() << " - " << fBaselineRange.Y() << endl;
+    RESTMetadata << "Threshold over baseline: " << fThresholdOverBaseline << RESTendl;
+    RESTMetadata << "Baseline range: " << fBaselineRange.X() << " - " << fBaselineRange.Y() << RESTendl;
 
-    cout << "Distance: " << fDistance << endl;
-    cout << "Window: " << fWindow << endl;
+    RESTMetadata << "Distance: " << fDistance << RESTendl;
+    RESTMetadata << "Window: " << fWindow << RESTendl;
 }

--- a/src/TRestRawPeaksFinderProcess.cxx
+++ b/src/TRestRawPeaksFinderProcess.cxx
@@ -188,6 +188,6 @@ void TRestRawPeaksFinderProcess::PrintMetadata() {
 
     RESTMetadata << "Distance: " << fDistance << RESTendl;
     RESTMetadata << "Window: " << fWindow << RESTendl;
-    
+
     EndPrintProcess();
 }

--- a/src/TRestRawPeaksFinderProcess.cxx
+++ b/src/TRestRawPeaksFinderProcess.cxx
@@ -11,6 +11,7 @@ void TRestRawPeaksFinderProcess::InitProcess() {}
 
 TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
     fSignalEvent = dynamic_cast<TRestRawSignalEvent*>(inputEvent);
+    
     const auto run = GetRunInfo();
     if (run != nullptr) {
         fSignalEvent->InitializeReferences(run);

--- a/src/TRestRawPeaksFinderProcess.cxx
+++ b/src/TRestRawPeaksFinderProcess.cxx
@@ -175,6 +175,8 @@ void TRestRawPeaksFinderProcess::InitFromConfigFile() {
 }
 
 void TRestRawPeaksFinderProcess::PrintMetadata() {
+    BeginPrintProcess();
+
     RESTMetadata << "Applying process to channel types: ";
     for (const auto& type : fChannelTypes) {
         RESTMetadata << type << " ";
@@ -186,4 +188,6 @@ void TRestRawPeaksFinderProcess::PrintMetadata() {
 
     RESTMetadata << "Distance: " << fDistance << RESTendl;
     RESTMetadata << "Window: " << fWindow << RESTendl;
+    
+    EndPrintProcess();
 }

--- a/src/TRestRawPeaksFinderProcess.cxx
+++ b/src/TRestRawPeaksFinderProcess.cxx
@@ -11,7 +11,7 @@ void TRestRawPeaksFinderProcess::InitProcess() {}
 
 TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
     fSignalEvent = dynamic_cast<TRestRawSignalEvent*>(inputEvent);
-    
+
     const auto run = GetRunInfo();
     if (run != nullptr) {
         fSignalEvent->InitializeReferences(run);

--- a/src/TRestRawSignalChannelActivityProcess.cxx
+++ b/src/TRestRawSignalChannelActivityProcess.cxx
@@ -143,14 +143,19 @@ void TRestRawSignalChannelActivityProcess::InitProcess() {
 /// \brief The main processing event function
 ///
 TRestEvent* TRestRawSignalChannelActivityProcess::ProcessEvent(TRestEvent* inputEvent) {
-    fSignalEvent = (TRestRawSignalEvent*)inputEvent;
+    fSignalEvent = dynamic_cast<TRestRawSignalEvent*>(inputEvent);
+
+    const auto run = GetRunInfo();
+    if (run != nullptr) {
+        fSignalEvent->InitializeReferences(run);
+    }
 
     if (fReadoutMetadata == nullptr) {
         fReadoutMetadata = fSignalEvent->GetReadoutMetadata();
     }
 
     if (fReadoutMetadata == nullptr && !fChannelType.empty()) {
-        cerr << "TRestRawCommonNoiseReductionProcess::ProcessEvent: readout metadata is null, cannot filter "
+        cerr << "TRestRawSignalChannelActivityProcess::ProcessEvent: readout metadata is null, cannot filter "
                 "the process by signal type"
              << endl;
         exit(1);

--- a/src/TRestRawSignalChannelActivityProcess.cxx
+++ b/src/TRestRawSignalChannelActivityProcess.cxx
@@ -43,7 +43,7 @@
 ///
 /// \htmlonly <style>div.image img[src="daqChActRaw.png"]{width:1000px;}</style>
 /// \endhtmlonly
-/// ![An ilustration of the daq raw signals channel activity](daqChActRaw.png)
+/// ![An illustration of the daq raw signals channel activity](daqChActRaw.png)
 ///
 /// * **rChannelActivityRaw**: histogram based on the readout channels, i.e.,
 /// after converting the daq channel numbering into readout channel numbering
@@ -128,7 +128,7 @@ void TRestRawSignalChannelActivityProcess::Initialize() {
 /// using
 /// the limits defined in the process metadata members.
 ///
-/// The readout histograms will only be created in case an appropiate readout
+/// The readout histograms will only be created in case an appropriate readout
 /// definition
 /// is found in the processing chain.
 ///
@@ -145,18 +145,28 @@ void TRestRawSignalChannelActivityProcess::InitProcess() {
 TRestEvent* TRestRawSignalChannelActivityProcess::ProcessEvent(TRestEvent* inputEvent) {
     fSignalEvent = (TRestRawSignalEvent*)inputEvent;
 
-    Int_t Nlow = 0;
-    Int_t Nhigh = 0;
-    for (int s = 0; s < fSignalEvent->GetNumberOfSignals(); s++) {
-        TRestRawSignal* sgnl = fSignalEvent->GetSignal(s);
-        if (sgnl->GetMaxValue() > fHighThreshold) Nhigh++;
-        if (sgnl->GetMaxValue() > fLowThreshold) Nlow++;
+    if (fReadoutMetadata == nullptr) {
+        fReadoutMetadata = fSignalEvent->GetReadoutMetadata();
+    }
+
+    if (fReadoutMetadata == nullptr && !fChannelType.empty()) {
+        cerr << "TRestRawCommonNoiseReductionProcess::ProcessEvent: readout metadata is null, cannot filter "
+                "the process by signal type"
+             << endl;
+        exit(1);
     }
 
     for (int s = 0; s < fSignalEvent->GetNumberOfSignals(); s++) {
+        const auto signal = fSignalEvent->GetSignal(s);
+        if (!fChannelType.empty()) {
+            const auto channelType = fReadoutMetadata->GetTypeForChannelDaqId(signal->GetID());
+            if (fChannelType != channelType) {
+                continue;
+            }
+        }
         // Adding signal to the channel activity histogram
         if (!fReadOnly) {
-            Int_t daqChannel = fSignalEvent->GetSignal(s)->GetID();
+            Int_t daqChannel = signal->GetID();
             fDaqChannelsHisto->Fill(daqChannel);
         }
     }

--- a/src/TRestRawSignalRemoveChannelsProcess.cxx
+++ b/src/TRestRawSignalRemoveChannelsProcess.cxx
@@ -147,7 +147,11 @@ void TRestRawSignalRemoveChannelsProcess::LoadConfig(const string& configFilenam
 ///
 TRestEvent* TRestRawSignalRemoveChannelsProcess::ProcessEvent(TRestEvent* inputEvent) {
     fInputSignalEvent = (TRestRawSignalEvent*)inputEvent;
-    fInputSignalEvent->InitializeReferences(GetRunInfo());
+
+    const auto run = GetRunInfo();
+    if (run != nullptr) {
+        fInputSignalEvent->InitializeReferences(run);
+    }
 
     if (fReadoutMetadata == nullptr) {
         fReadoutMetadata = fInputSignalEvent->GetReadoutMetadata();

--- a/src/TRestRawSignalRemoveChannelsProcess.cxx
+++ b/src/TRestRawSignalRemoveChannelsProcess.cxx
@@ -146,7 +146,7 @@ void TRestRawSignalRemoveChannelsProcess::LoadConfig(const string& configFilenam
 /// \brief The main processing event function
 ///
 TRestEvent* TRestRawSignalRemoveChannelsProcess::ProcessEvent(TRestEvent* inputEvent) {
-    fInputSignalEvent = (TRestRawSignalEvent*)inputEvent;
+    fInputSignalEvent = dynamic_cast<TRestRawSignalEvent*>(inputEvent);
 
     const auto run = GetRunInfo();
     if (run != nullptr) {

--- a/src/TRestRawVetoAnalysisProcess.cxx
+++ b/src/TRestRawVetoAnalysisProcess.cxx
@@ -199,10 +199,7 @@ void TRestRawVetoAnalysisProcess::LoadConfig(const string& configFilename, const
 /// \brief Function to use in initialization of process members before starting
 /// to process the event
 ///
-void TRestRawVetoAnalysisProcess::InitProcess() {
-    // For example, try to initialize a pointer to existing metadata
-    // accessible from TRestRun
-}
+void TRestRawVetoAnalysisProcess::InitProcess() {}
 
 ///////////////////////////////////////////////
 /// \brief Function to initialize input/output event members and define the
@@ -451,6 +448,13 @@ void TRestRawVetoAnalysisProcess::InitFromConfigFile() {
 ///
 void TRestRawVetoAnalysisProcess::PrintMetadata() {
     BeginPrintProcess();
+
+    if ((fVetoSignalId.empty() || fVetoSignalId[0] != -1) && fVetoGroupNames.empty()) {
+        RESTMetadata
+            << "Veto analysis process will apply to veto signals (to be determined during processing)"
+            << RESTendl;
+        return;
+    }
 
     for (unsigned int i = 0; i < fVetoGroupNames.size(); i++) {
         RESTMetadata << "Veto group " << fVetoGroupNames[i] << " signal IDs: " << fVetoGroupIds[i]

--- a/src/TRestRawVetoAnalysisProcess.cxx
+++ b/src/TRestRawVetoAnalysisProcess.cxx
@@ -218,6 +218,11 @@ void TRestRawVetoAnalysisProcess::Initialize() {
 TRestEvent* TRestRawVetoAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     fSignalEvent = (TRestRawSignalEvent*)inputEvent;
 
+    const auto run = GetRunInfo();
+    if (run != nullptr) {
+        fSignalEvent->InitializeReferences(run);
+    }
+
     map<int, Double_t> VetoMaxPeakAmplitude_map;
     map<int, Double_t> VetoPeakTime_map;
 

--- a/src/TRestRawVetoAnalysisProcess.cxx
+++ b/src/TRestRawVetoAnalysisProcess.cxx
@@ -90,12 +90,12 @@
 /// which returns a std::pair<vector<string>,vector<string>>, which contains in the first entry the name of
 /// the veto group,
 /// and in the second the comma separated string of the corresponding signal IDs. The signal IDs can
-/// susequently be converted
+/// subsequently be converted
 /// into a vector<double> by using the TRestStringHelper::StringToElements() method.
 ///
 /// <hr>
 ///
-/// \warning **⚠ REST is under continous development.** This documentation
+/// \warning **⚠ REST is under continuous development.** This documentation
 /// is offered to you by the REST community. Your HELP is needed to keep this code
 /// up to date. Your feedback will be worth to support this software, please report
 /// any problems/suggestions you may find while using it at [The REST Framework
@@ -452,7 +452,6 @@ void TRestRawVetoAnalysisProcess::InitFromConfigFile() {
 void TRestRawVetoAnalysisProcess::PrintMetadata() {
     BeginPrintProcess();
 
-    // Print output metadata using, metadata << endl;
     for (unsigned int i = 0; i < fVetoGroupNames.size(); i++) {
         RESTMetadata << "Veto group " << fVetoGroupNames[i] << " signal IDs: " << fVetoGroupIds[i]
                      << RESTendl;


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Large: 260](https://badgen.net/badge/PR%20Size/Large%3A%20260/red) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/129-support-multiple-readout-channel-types-on-processes/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/129-support-multiple-readout-channel-types-on-processes) [![](https://github.com/rest-for-physics/rawlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=129-support-multiple-readout-channel-types-on-processes)](https://github.com/rest-for-physics/rawlib/commits/129-support-multiple-readout-channel-types-on-processes) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

