### PR TITLE
Consistent name of the input events in the processes

### DIFF
--- a/inc/TRestRawPeaksFinderProcess.h
+++ b/inc/TRestRawPeaksFinderProcess.h
@@ -12,7 +12,7 @@
 
 class TRestRawPeaksFinderProcess : public TRestEventProcess {
    private:
-    TRestRawSignalEvent* fInputEvent = nullptr;          //!
+    TRestRawSignalEvent* fInputEvent = nullptr;           //!
     TRestRawReadoutMetadata* fReadoutMetadata = nullptr;  //!
 
     /// \brief threshold over baseline to consider a peak

--- a/inc/TRestRawPeaksFinderProcess.h
+++ b/inc/TRestRawPeaksFinderProcess.h
@@ -12,7 +12,7 @@
 
 class TRestRawPeaksFinderProcess : public TRestEventProcess {
    private:
-    TRestRawSignalEvent* fSignalEvent = nullptr;          //!
+    TRestRawSignalEvent* fInputEvent = nullptr;          //!
     TRestRawReadoutMetadata* fReadoutMetadata = nullptr;  //!
 
     /// \brief threshold over baseline to consider a peak
@@ -27,8 +27,8 @@ class TRestRawPeaksFinderProcess : public TRestEventProcess {
     std::set<std::string> fChannelTypes = {};  // this process will only be applied to selected channel types
 
    public:
-    RESTValue GetInputEvent() const override { return fSignalEvent; }
-    RESTValue GetOutputEvent() const override { return fSignalEvent; }
+    RESTValue GetInputEvent() const override { return fInputEvent; }
+    RESTValue GetOutputEvent() const override { return fInputEvent; }
 
     void PrintMetadata() override;
 

--- a/inc/TRestRawSignalAnalysisProcess.h
+++ b/inc/TRestRawSignalAnalysisProcess.h
@@ -31,7 +31,7 @@
 class TRestRawSignalAnalysisProcess : public TRestEventProcess {
    private:
     /// A pointer to the specific TRestRawSignalEvent input
-    TRestRawSignalEvent* fSignalEvent;  //!
+    TRestRawSignalEvent* fInputEvent;  //!
 
     /// Just a flag to quickly determine if we have to apply the range filter
     Bool_t fRangeEnabled = false;  //!
@@ -70,9 +70,9 @@ class TRestRawSignalAnalysisProcess : public TRestEventProcess {
     // add here the members of your event process
 
    public:
-    RESTValue GetInputEvent() const override { return fSignalEvent; }
+    RESTValue GetInputEvent() const override { return fInputEvent; }
 
-    RESTValue GetOutputEvent() const override { return fSignalEvent; }
+    RESTValue GetOutputEvent() const override { return fInputEvent; }
 
     void InitProcess() override;
 

--- a/inc/TRestRawSignalChannelActivityProcess.h
+++ b/inc/TRestRawSignalChannelActivityProcess.h
@@ -52,7 +52,7 @@ class TRestRawSignalChannelActivityProcess : public TRestEventProcess {
 
    private:
     /// A pointer to the specific TRestRawSignalEvent input
-    TRestRawSignalEvent* fSignalEvent = nullptr;  //!
+    TRestRawSignalEvent* fInputEvent = nullptr;  //!
 
     std::string fChannelType;
     TRestRawReadoutMetadata* fReadoutMetadata = nullptr;  //!
@@ -60,8 +60,8 @@ class TRestRawSignalChannelActivityProcess : public TRestEventProcess {
     void Initialize() override;
 
    public:
-    RESTValue GetInputEvent() const override { return fSignalEvent; }
-    RESTValue GetOutputEvent() const override { return fSignalEvent; }
+    RESTValue GetInputEvent() const override { return fInputEvent; }
+    RESTValue GetOutputEvent() const override { return fInputEvent; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/inc/TRestRawSignalRemoveChannelsProcess.h
+++ b/inc/TRestRawSignalRemoveChannelsProcess.h
@@ -32,10 +32,10 @@
 class TRestRawSignalRemoveChannelsProcess : public TRestEventProcess {
    private:
     /// A pointer to the specific TRestDetectorSignalEvent input
-    TRestRawSignalEvent* fInputSignalEvent;  //!
+    TRestRawSignalEvent* fInputEvent;  //!
 
     /// A pointer to the specific TRestRawSignalEvent input
-    TRestRawSignalEvent* fOutputSignalEvent;  //!
+    TRestRawSignalEvent* fOutputEvent;  //!
 
     /// A pointer to the readout metadata
     TRestRawReadoutMetadata* fReadoutMetadata = nullptr;  //!
@@ -53,8 +53,8 @@ class TRestRawSignalRemoveChannelsProcess : public TRestEventProcess {
     std::map<Int_t, std::string> fChannelTypesToRemove;
 
    public:
-    RESTValue GetInputEvent() const override { return fInputSignalEvent; }
-    RESTValue GetOutputEvent() const override { return fOutputSignalEvent; }
+    RESTValue GetInputEvent() const override { return fInputEvent; }
+    RESTValue GetOutputEvent() const override { return fOutputEvent; }
 
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;
 

--- a/src/TRestRawBaseLineCorrectionProcess.cxx
+++ b/src/TRestRawBaseLineCorrectionProcess.cxx
@@ -88,8 +88,8 @@ void TRestRawBaseLineCorrectionProcess::Initialize() {
     fOutputEvent = new TRestRawSignalEvent();
 }
 
-TRestEvent* TRestRawBaseLineCorrectionProcess::ProcessEvent(TRestEvent* evInput) {
-    fInputEvent = dynamic_cast<TRestRawSignalEvent*>(evInput);
+TRestEvent* TRestRawBaseLineCorrectionProcess::ProcessEvent(TRestEvent* inputEvent) {
+    fInputEvent = dynamic_cast<TRestRawSignalEvent*>(inputEvent);
 
     const auto run = GetRunInfo();
     if (run != nullptr) {

--- a/src/TRestRawPeaksFinderProcess.cxx
+++ b/src/TRestRawPeaksFinderProcess.cxx
@@ -10,17 +10,17 @@ using namespace std;
 void TRestRawPeaksFinderProcess::InitProcess() {}
 
 TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
-    fSignalEvent = dynamic_cast<TRestRawSignalEvent*>(inputEvent);
+    fInputEvent = dynamic_cast<TRestRawSignalEvent*>(inputEvent);
 
     const auto run = GetRunInfo();
     if (run != nullptr) {
-        fSignalEvent->InitializeReferences(run);
+        fInputEvent->InitializeReferences(run);
     }
 
-    auto event = fSignalEvent->GetSignalEventForTypes(fChannelTypes, fReadoutMetadata);
+    auto event = fInputEvent->GetSignalEventForTypes(fChannelTypes, fReadoutMetadata);
 
     if (fReadoutMetadata == nullptr) {
-        fReadoutMetadata = fSignalEvent->GetReadoutMetadata();
+        fReadoutMetadata = fInputEvent->GetReadoutMetadata();
     }
 
     if (fReadoutMetadata == nullptr && !fChannelTypes.empty()) {

--- a/src/TRestRawSignalAnalysisProcess.cxx
+++ b/src/TRestRawSignalAnalysisProcess.cxx
@@ -312,7 +312,7 @@ TRestEvent* TRestRawSignalAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) 
              << endl;
         exit(1);
     }
-    
+
     auto event = fInputEvent->GetSignalEventForTypes(fChannelTypes, fReadoutMetadata);
 
     // we save some complex typed analysis result

--- a/src/TRestRawSignalChannelActivityProcess.cxx
+++ b/src/TRestRawSignalChannelActivityProcess.cxx
@@ -120,7 +120,7 @@ void TRestRawSignalChannelActivityProcess::Initialize() {
     SetSectionName(this->ClassName());
     SetLibraryVersion(LIBRARY_VERSION);
 
-    fSignalEvent = nullptr;
+    fInputEvent = nullptr;
 }
 
 ///////////////////////////////////////////////
@@ -143,15 +143,15 @@ void TRestRawSignalChannelActivityProcess::InitProcess() {
 /// \brief The main processing event function
 ///
 TRestEvent* TRestRawSignalChannelActivityProcess::ProcessEvent(TRestEvent* inputEvent) {
-    fSignalEvent = dynamic_cast<TRestRawSignalEvent*>(inputEvent);
+    fInputEvent = dynamic_cast<TRestRawSignalEvent*>(inputEvent);
 
     const auto run = GetRunInfo();
     if (run != nullptr) {
-        fSignalEvent->InitializeReferences(run);
+        fInputEvent->InitializeReferences(run);
     }
 
     if (fReadoutMetadata == nullptr) {
-        fReadoutMetadata = fSignalEvent->GetReadoutMetadata();
+        fReadoutMetadata = fInputEvent->GetReadoutMetadata();
     }
 
     if (fReadoutMetadata == nullptr && !fChannelType.empty()) {
@@ -161,8 +161,8 @@ TRestEvent* TRestRawSignalChannelActivityProcess::ProcessEvent(TRestEvent* input
         exit(1);
     }
 
-    for (int s = 0; s < fSignalEvent->GetNumberOfSignals(); s++) {
-        const auto signal = fSignalEvent->GetSignal(s);
+    for (int s = 0; s < fInputEvent->GetNumberOfSignals(); s++) {
+        const auto signal = fInputEvent->GetSignal(s);
         if (!fChannelType.empty()) {
             const auto channelType = fReadoutMetadata->GetTypeForChannelDaqId(signal->GetID());
             if (fChannelType != channelType) {
@@ -179,7 +179,7 @@ TRestEvent* TRestRawSignalChannelActivityProcess::ProcessEvent(TRestEvent* input
     if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
         fAnalysisTree->PrintObservables();
 
-    return fSignalEvent;
+    return fInputEvent;
 }
 
 ///////////////////////////////////////////////

--- a/src/TRestRawSignalRemoveChannelsProcess.cxx
+++ b/src/TRestRawSignalRemoveChannelsProcess.cxx
@@ -102,7 +102,7 @@ TRestRawSignalRemoveChannelsProcess::TRestRawSignalRemoveChannelsProcess(const c
 ///////////////////////////////////////////////
 /// \brief Default destructor
 ///
-TRestRawSignalRemoveChannelsProcess::~TRestRawSignalRemoveChannelsProcess() { delete fOutputSignalEvent; }
+TRestRawSignalRemoveChannelsProcess::~TRestRawSignalRemoveChannelsProcess() { delete fOutputEvent; }
 
 ///////////////////////////////////////////////
 /// \brief Function to load the default config in absence of RML input
@@ -120,8 +120,8 @@ void TRestRawSignalRemoveChannelsProcess::Initialize() {
     SetSectionName(this->ClassName());
     SetLibraryVersion(LIBRARY_VERSION);
 
-    fInputSignalEvent = nullptr;
-    fOutputSignalEvent = new TRestRawSignalEvent();
+    fInputEvent = nullptr;
+    fOutputEvent = new TRestRawSignalEvent();
 }
 
 ///////////////////////////////////////////////
@@ -146,15 +146,15 @@ void TRestRawSignalRemoveChannelsProcess::LoadConfig(const string& configFilenam
 /// \brief The main processing event function
 ///
 TRestEvent* TRestRawSignalRemoveChannelsProcess::ProcessEvent(TRestEvent* inputEvent) {
-    fInputSignalEvent = dynamic_cast<TRestRawSignalEvent*>(inputEvent);
+    fInputEvent = dynamic_cast<TRestRawSignalEvent*>(inputEvent);
 
     const auto run = GetRunInfo();
     if (run != nullptr) {
-        fInputSignalEvent->InitializeReferences(run);
+        fInputEvent->InitializeReferences(run);
     }
 
     if (fReadoutMetadata == nullptr) {
-        fReadoutMetadata = fInputSignalEvent->GetReadoutMetadata();
+        fReadoutMetadata = fInputEvent->GetReadoutMetadata();
     }
 
     if (fReadoutMetadata == nullptr && !fChannelTypes.empty()) {
@@ -164,8 +164,8 @@ TRestEvent* TRestRawSignalRemoveChannelsProcess::ProcessEvent(TRestEvent* inputE
         exit(1);
     }
 
-    for (int n = 0; n < fInputSignalEvent->GetNumberOfSignals(); n++) {
-        TRestRawSignal* signal = fInputSignalEvent->GetSignal(n);
+    for (int n = 0; n < fInputEvent->GetNumberOfSignals(); n++) {
+        TRestRawSignal* signal = fInputEvent->GetSignal(n);
 
         bool removeSignal = false;
 
@@ -195,7 +195,7 @@ TRestEvent* TRestRawSignalRemoveChannelsProcess::ProcessEvent(TRestEvent* inputE
         }
 
         if (!removeSignal) {
-            fOutputSignalEvent->AddSignal(*signal);
+            fOutputEvent->AddSignal(*signal);
         }
 
         // Logging messages
@@ -212,7 +212,7 @@ TRestEvent* TRestRawSignalRemoveChannelsProcess::ProcessEvent(TRestEvent* inputE
         GetChar();
     }
 
-    return fOutputSignalEvent;
+    return fOutputEvent;
 }
 
 ///////////////////////////////////////////////


### PR DESCRIPTION
![JPorron](https://badgen.net/badge/PR%20submitted%20by%3A/JPorron/blue) ![Ok: 59](https://badgen.net/badge/PR%20Size/Ok%3A%2059/green) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/inputname-in-processes-consistency/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/inputname-in-processes-consistency) [![](https://github.com/rest-for-physics/rawlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=inputname-in-processes-consistency)](https://github.com/rest-for-physics/rawlib/commits/inputname-in-processes-consistency) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

