### PR TITLE
Small changes in TRestRawSignalChannelActivityProcess

### DIFF
--- a/inc/TRestRawSignalChannelActivityProcess.h
+++ b/inc/TRestRawSignalChannelActivityProcess.h
@@ -32,11 +32,6 @@
 //! activity
 class TRestRawSignalChannelActivityProcess : public TRestEventProcess {
    protected:
-    /// The value of the lower signal threshold to add it to the histogram
-    Double_t fLowThreshold = 25;
-
-    /// The value of the higher signal threshold to add it to the histogram
-    Double_t fHighThreshold = 50;
 
     /// The number of bins at the daq channels histogram
     Int_t fDaqChannels = 300;
@@ -74,9 +69,6 @@ class TRestRawSignalChannelActivityProcess : public TRestEventProcess {
         if (!fChannelType.empty()) {
             RESTMetadata << "channelType : " << fChannelType << RESTendl;
         }
-
-        RESTMetadata << "Low signal threshold activity : " << fLowThreshold << RESTendl;
-        RESTMetadata << "High signal threshold activity : " << fHighThreshold << RESTendl;
 
         RESTMetadata << "Number of daq histogram channels : " << fDaqChannels << RESTendl;
         RESTMetadata << "Start daq channel : " << fDaqStartChannel << RESTendl;

--- a/inc/TRestRawSignalChannelActivityProcess.h
+++ b/inc/TRestRawSignalChannelActivityProcess.h
@@ -32,7 +32,6 @@
 //! activity
 class TRestRawSignalChannelActivityProcess : public TRestEventProcess {
    protected:
-
     /// The number of bins at the daq channels histogram
     Int_t fDaqChannels = 300;
 

--- a/src/TRestRawSignalChannelActivityProcess.cxx
+++ b/src/TRestRawSignalChannelActivityProcess.cxx
@@ -134,7 +134,11 @@ void TRestRawSignalChannelActivityProcess::Initialize() {
 ///
 void TRestRawSignalChannelActivityProcess::InitProcess() {
     if (!fReadOnly) {
-        fDaqChannelsHisto = new TH1D("daqChannelActivityRaw", "daqChannelActivityRaw", fDaqChannels,
+        // Create a unique histogram name based on signal type
+        string histogramName = "daqChannelActivityRaw_" + fChannelType;
+
+        // Create the histogram using the unique name
+        fDaqChannelsHisto = new TH1D(histogramName.c_str(), histogramName.c_str(), fDaqChannels,
                                      fDaqStartChannel, fDaqEndChannel);
     }
 }


### PR DESCRIPTION
![JPorron](https://badgen.net/badge/PR%20submitted%20by%3A/JPorron/blue) ![Ok: 5](https://badgen.net/badge/PR%20Size/Ok%3A%205/green) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/solve-histogram-name-issue/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/solve-histogram-name-issue) [![](https://github.com/rest-for-physics/rawlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=solve-histogram-name-issue)](https://github.com/rest-for-physics/rawlib/commits/solve-histogram-name-issue) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Two parameters are removed as they are not used (they are used in the similar TRestDetectorSignalChannelActivityProcess) and the histogram name is changed to avoid overwritting when the process is run twice for two different event types.