### PR TITLE
TRestRawMultiFEMINOSToSignalProcess exits when processing a stopped run .aqs file

### DIFF
--- a/src/TRestRawMultiFEMINOSToSignalProcess.cxx
+++ b/src/TRestRawMultiFEMINOSToSignalProcess.cxx
@@ -363,7 +363,7 @@ TRestEvent* TRestRawMultiFEMINOSToSignalProcess::ProcessEvent(TRestEvent* inputE
             if (!endOfEvent) {
                 if (fread(&(cur_fr[fr_offset]), sizeof(unsigned short), nb_sh, fInputBinFile) != nb_sh) {
                     printf("Error: could not read %d bytes.\n", (nb_sh * 2));
-                    return nullptr; // exit(1);
+                    return nullptr;  // exit(1);
                 }
                 totalBytesReaded += sizeof(unsigned short) * nb_sh;
 

--- a/src/TRestRawMultiFEMINOSToSignalProcess.cxx
+++ b/src/TRestRawMultiFEMINOSToSignalProcess.cxx
@@ -363,7 +363,7 @@ TRestEvent* TRestRawMultiFEMINOSToSignalProcess::ProcessEvent(TRestEvent* inputE
             if (!endOfEvent) {
                 if (fread(&(cur_fr[fr_offset]), sizeof(unsigned short), nb_sh, fInputBinFile) != nb_sh) {
                     printf("Error: could not read %d bytes.\n", (nb_sh * 2));
-                    exit(1);
+                    return nullptr; // exit(1);
                 }
                 totalBytesReaded += sizeof(unsigned short) * nb_sh;
 


### PR DESCRIPTION
![AlvaroEzq](https://badgen.net/badge/PR%20submitted%20by%3A/AlvaroEzq/blue) ![Ok: 1](https://badgen.net/badge/PR%20Size/Ok%3A%201/green) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/alvaroezq_fixStopRuns/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/alvaroezq_fixStopRuns) [![](https://github.com/rest-for-physics/rawlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=alvaroezq_fixStopRuns)](https://github.com/rest-for-physics/rawlib/commits/alvaroezq_fixStopRuns) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Solving issue [#135 ](https://github.com/rest-for-physics/rawlib/issues/135).