### PR TITLE
Increase permited equal or bigger neighbor bins to relax peaksFinder conditions

### DIFF
--- a/src/TRestRawSignal.cxx
+++ b/src/TRestRawSignal.cxx
@@ -969,7 +969,7 @@ vector<pair<UShort_t, double>> TRestRawSignal::GetPeaks(double threshold, UShort
                 if (j != i && smoothedValue <= smoothedValues[j]) {
                     numGreaterEqual++;
                     if (numGreaterEqual >
-                        2) {  // If more than one smoothed value is greater or equal, it's not a peak
+                        3) {  // If more than one smoothed value is greater or equal, it's not a peak
                         isPeak = false;
                         break;
                     }


### PR DESCRIPTION
![JPorron](https://badgen.net/badge/PR%20submitted%20by%3A/JPorron/blue) ![Ok: 1](https://badgen.net/badge/PR%20Size/Ok%3A%201/green) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/jporron-loosen-peakFinder-conditions/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/jporron-loosen-peakFinder-conditions) [![](https://github.com/rest-for-physics/rawlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=jporron-loosen-peakFinder-conditions)](https://github.com/rest-for-physics/rawlib/commits/jporron-loosen-peakFinder-conditions) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The condition to identify a bin as a peak is to compare the smoothed value of each bin with its 5 neighbouring bins in each direction. If there are more than the changed value neighbour bins equal or higher than the smoothed value of the corresponding bin then it is not a peak. This way the first bin (within the "distance" parameter) that has no more than this number of equal or bigger neighbours is the peak (no more bins within "distance" can be peaks).

I found some cases where setting the value to >2 was not letting some signals detect a peak (if the region of the maximum is flat along several bins). I think >3 is a better compromise to not allow very flat regions to be considered as peak while detecting clear peaks.