### PR TITLE
Update peak finder process

### DIFF
--- a/inc/TRestRawPeaksFinderProcess.h
+++ b/inc/TRestRawPeaksFinderProcess.h
@@ -30,6 +30,10 @@ class TRestRawPeaksFinderProcess : public TRestEventProcess {
 
     Double_t fTimeBinToTimeFactorMultiplier = 0.0;
     Double_t fTimeBinToTimeFactorOffset = 0.0;
+    Double_t fTimeBinToTimeFactorOffsetTCM = 0.0;
+
+    Bool_t fTimeConversionElectronics = false;
+
     Double_t fADCtoEnergyFactor = 0.0;
     std::map<UShort_t, Double_t> fChannelIDToADCtoEnergyFactor = {};
 

--- a/inc/TRestRawPeaksFinderProcess.h
+++ b/inc/TRestRawPeaksFinderProcess.h
@@ -19,14 +19,19 @@ class TRestRawPeaksFinderProcess : public TRestEventProcess {
     Double_t fThresholdOverBaseline = 2.0;
     /// \brief range of samples to calculate baseline for peak finding
     TVector2 fBaselineRange = {0, 10};
-    /// \brief distance between two peaks to consider them as different
+    /// \brief distance between two peaks to consider them as different (ADC units)
     UShort_t fDistance = 10;
-    /// \brief window size to calculate the peak amplitude
+    /// \brief window size to calculate the peak amplitude (time bins)
     UShort_t fWindow = 10;
     /// \brief option to remove all veto signals after finding the peaks
-    Bool_t fRemoveAllVetos = false;
-    /// \brief option to remove peakless veto signals after finding the peaks
-    Bool_t fRemovePeaklessVetos = false;
+    Bool_t fRemoveAllVetoes = false;
+    /// \brief option to remove peak-less veto signals after finding the peaks
+    Bool_t fRemovePeaklessVetoes = false;
+
+    Double_t fTimeBinToTimeFactorMultiplier = 0.0;
+    Double_t fTimeBinToTimeFactorOffset = 0.0;
+    Double_t fADCtoEnergyFactor = 0.0;
+    std::map<UShort_t, Double_t> fChannelIDToADCtoEnergyFactor = {};
 
     std::set<std::string> fChannelTypes = {};  // this process will only be applied to selected channel types
 
@@ -42,14 +47,14 @@ class TRestRawPeaksFinderProcess : public TRestEventProcess {
 
     const char* GetProcessName() const override { return "peaksFinder"; }
 
-    explicit TRestRawPeaksFinderProcess(const char* configFilename){};
+    explicit TRestRawPeaksFinderProcess(const char* configFilename) {};
 
     void InitFromConfigFile() override;
 
     TRestRawPeaksFinderProcess() = default;
     ~TRestRawPeaksFinderProcess() = default;
 
-    ClassDefOverride(TRestRawPeaksFinderProcess, 4);
+    ClassDefOverride(TRestRawPeaksFinderProcess, 5);
 };
 
 #endif  // REST_TRESTRAWPEAKSFINDERPROCESS_H

--- a/src/TRestRawPeaksFinderProcess.cxx
+++ b/src/TRestRawPeaksFinderProcess.cxx
@@ -171,7 +171,6 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("windowTimeBin", windowCenter);
     SetObservableValue("windowMultiplicity", windowMultiplicity);
 
-    // if defined, convert time bins to time and amplitude to energy
     if (fTimeBinToTimeFactorMultiplier != 0.0) {
         vector<Double_t> windowCenterTime(windowCenter.size(), 0.0);
         vector<Double_t> windowPeakCenterTime(windowPeakCenter.size(), 0.0);
@@ -321,11 +320,10 @@ void TRestRawPeaksFinderProcess::InitFromConfigFile() {
     fRemoveAllVetoes = StringToBool(GetParameter("removeAllVetos", fRemoveAllVetoes));
     fRemovePeaklessVetoes = StringToBool(GetParameter("removePeaklessVetos", fRemovePeaklessVetoes));
 
-    fTimeBinToTimeFactorMultiplier =
-        GetDblParameterWithUnits(GetParameter("sampling", fTimeBinToTimeFactorMultiplier));
-    fTimeBinToTimeFactorOffset = GetDblParameterWithUnits(GetParameter("delay", fTimeBinToTimeFactorOffset));
+    fTimeBinToTimeFactorMultiplier = GetDblParameterWithUnits("sampling", fTimeBinToTimeFactorMultiplier);
+    fTimeBinToTimeFactorOffset = GetDblParameterWithUnits("delay", fTimeBinToTimeFactorOffset);
 
-    fADCtoEnergyFactor = GetDblParameterWithUnits(GetParameter("adcToEnergyFactor", fADCtoEnergyFactor));
+    fADCtoEnergyFactor = GetDblParameterWithUnits("adcToEnergyFactor", fADCtoEnergyFactor);
     const string fChannelIDToADCtoEnergyFactorAsString = GetParameter("channelIDToADCtoEnergyFactor", "");
     if (!fChannelIDToADCtoEnergyFactorAsString.empty()) {
         // map should be in the format: "{channelId1: factor1, channelId2: factor2, ...}" (spaces are allowed

--- a/src/TRestRawPeaksFinderProcess.cxx
+++ b/src/TRestRawPeaksFinderProcess.cxx
@@ -102,9 +102,9 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("peaksCount", peaksCount);
     SetObservableValue("peaksCountUnique", peaksCountUnique);
 
-    vector<UShort_t> windowIndex(eventPeaks.size(), 0);
-    vector<UShort_t> windowCenter(eventPeaks.size(), 0);
-    vector<UShort_t> windowMultiplicity(eventPeaks.size(), 0);
+    vector<UShort_t> windowPeakIndex(eventPeaks.size(), 0);
+    vector<UShort_t> windowPeakCenter(eventPeaks.size(), 0);
+    vector<UShort_t> windowPeakMultiplicity(eventPeaks.size(), 0);
 
     UShort_t window_index = 0;
     for (size_t peakIndex = 0; peakIndex < eventPeaks.size(); peakIndex++) {
@@ -113,7 +113,7 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
         const auto windowTimeEnd = time + fWindow / 2;
 
         // check if the peak is already in a window
-        if (windowIndex[peakIndex] != 0) {
+        if (windowPeakIndex[peakIndex] != 0) {
             continue;
         }
 
@@ -140,15 +140,34 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
         }
 
         for (const auto& index : windowPeaksIndex) {
-            windowIndex[index] = window_index;
-            windowCenter[index] = window_center_time;
-            windowMultiplicity[index] = windowPeaksIndex.size();
+            windowPeakIndex[index] = window_index;
+            windowPeakCenter[index] = window_center_time;
+            windowPeakMultiplicity[index] = windowPeaksIndex.size();
         }
 
         window_index++;
     }
 
-    SetObservableValue("windowIndex", windowIndex);
+    SetObservableValue("windowPeakIndex", windowPeakIndex);
+    SetObservableValue("windowPeakCenter", windowPeakCenter);
+    SetObservableValue("windowPeakMultiplicity", windowPeakMultiplicity);
+
+    vector<UShort_t> windowCenter;
+    vector<UShort_t> windowMultiplicity;
+
+    set<UShort_t> windowPeaksIndexInserted;
+    for (size_t peakIndex = 0; peakIndex < eventPeaks.size(); peakIndex++) {
+        const auto& window_peak_index = windowPeakIndex[peakIndex];
+        if (windowPeaksIndexInserted.find(window_peak_index) != windowPeaksIndexInserted.end()) {
+            continue;
+        }
+
+        windowPeaksIndexInserted.insert(window_peak_index);
+
+        windowCenter.push_back(windowPeakCenter[peakIndex]);
+        windowMultiplicity.push_back(windowPeakMultiplicity[peakIndex]);
+    }
+
     SetObservableValue("windowCenter", windowCenter);
     SetObservableValue("windowMultiplicity", windowMultiplicity);
 

--- a/src/TRestRawPeaksFinderProcess.cxx
+++ b/src/TRestRawPeaksFinderProcess.cxx
@@ -102,7 +102,7 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("peaksCount", peaksCount);
     SetObservableValue("peaksCountUnique", peaksCountUnique);
 
-    vector<UShort_t> windowPeakIndex(eventPeaks.size(), 0);
+    vector<UShort_t> windowPeakIndex(eventPeaks.size(), std::numeric_limits<UShort_t>::max());
     vector<UShort_t> windowPeakCenter(eventPeaks.size(), 0);
     vector<UShort_t> windowPeakMultiplicity(eventPeaks.size(), 0);
 
@@ -113,7 +113,7 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
         const auto windowTimeEnd = time + fWindow / 2;
 
         // check if the peak is already in a window
-        if (windowPeakIndex[peakIndex] != 0) {
+        if (windowPeakIndex[peakIndex] != std::numeric_limits<UShort_t>::max()) {
             continue;
         }
 

--- a/src/TRestRawPeaksFinderProcess.cxx
+++ b/src/TRestRawPeaksFinderProcess.cxx
@@ -321,15 +321,23 @@ void TRestRawPeaksFinderProcess::InitFromConfigFile() {
     fRemoveAllVetoes = StringToBool(GetParameter("removeAllVetos", fRemoveAllVetoes));
     fRemovePeaklessVetoes = StringToBool(GetParameter("removePeaklessVetos", fRemovePeaklessVetoes));
 
-    fTimeBinToTimeFactorMultiplier = StringToDouble(GetParameter("sampling", fTimeBinToTimeFactorMultiplier));
-    fTimeBinToTimeFactorOffset = StringToDouble(GetParameter("delay", fTimeBinToTimeFactorOffset));
+    fTimeBinToTimeFactorMultiplier =
+        GetDblParameterWithUnits(GetParameter("sampling", fTimeBinToTimeFactorMultiplier));
+    fTimeBinToTimeFactorOffset = GetDblParameterWithUnits(GetParameter("delay", fTimeBinToTimeFactorOffset));
 
-    fADCtoEnergyFactor = StringToDouble(GetParameter("adcToEnergyFactor", fADCtoEnergyFactor));
+    fADCtoEnergyFactor = GetDblParameterWithUnits(GetParameter("adcToEnergyFactor", fADCtoEnergyFactor));
     const string fChannelIDToADCtoEnergyFactorAsString = GetParameter("channelIDToADCtoEnergyFactor", "");
     if (!fChannelIDToADCtoEnergyFactorAsString.empty()) {
         // map should be in the format: "{channelId1: factor1, channelId2: factor2, ...}" (spaces are allowed
         // but not required)
         fChannelIDToADCtoEnergyFactor = parseStringToMap(fChannelIDToADCtoEnergyFactorAsString);
+    }
+
+    if (fADCtoEnergyFactor != 0 && !fChannelIDToADCtoEnergyFactor.empty()) {
+        cerr << "TRestRawPeaksFinderProcess::InitFromConfigFile: both adcToEnergyFactor and "
+                "channelIDToADCtoEnergyFactor are defined. Please, remove one of them."
+             << endl;
+        exit(1);
     }
 
     if (fBaselineRange.X() > fBaselineRange.Y() || fBaselineRange.X() < 0 || fBaselineRange.Y() < 0) {


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 37](https://badgen.net/badge/PR%20Size/Ok%3A%2037/green) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/lobis-peak-finder-upgrade/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/lobis-peak-finder-upgrade) [![](https://github.com/rest-for-physics/rawlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=lobis-peak-finder-upgrade)](https://github.com/rest-for-physics/rawlib/commits/lobis-peak-finder-upgrade) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

It is now possible to specify a time and energy conversion to save times and amplitudes as physical units in a separate observable.

Time conversion is controlled via the following parameters:

- `sampling` : sampling time. If defined the times will also be stored in physical units.
- `delay`: computed times will be substrated `delay`. this parameter is set in time units, not time bins.

These parameters control how ADC units are converted into energy. Only one should be specified.

- `adcToEnergyFactor`: single factor to convert ADC units into energy (multiplicative).
- `channelIDToADCtoEnergyFactor`: a mapping between channel ids and multiplicative factors to convert ADC units to energy. It should be specified as a string in the following format: `"{channelId1: factor1, channelId2: factor2, ...}"`.