### PR TITLE
Jporron update veto peaks finder

### DIFF
--- a/inc/TRestRawPeaksFinderProcess.h
+++ b/inc/TRestRawPeaksFinderProcess.h
@@ -17,6 +17,8 @@ class TRestRawPeaksFinderProcess : public TRestEventProcess {
 
     /// \brief threshold over baseline to consider a peak
     Double_t fThresholdOverBaseline = 2.0;
+    /// \brief choose times the sigma of the baseline must be overcome to consider a peak
+    Double_t fSigmaOverBaseline = 10.0;
     /// \brief range of samples to calculate baseline for peak finding
     TVector2 fBaselineRange = {0, 10};
     /// \brief distance between two peaks to consider them as different (ADC units)
@@ -58,7 +60,7 @@ class TRestRawPeaksFinderProcess : public TRestEventProcess {
     TRestRawPeaksFinderProcess() = default;
     ~TRestRawPeaksFinderProcess() = default;
 
-    ClassDefOverride(TRestRawPeaksFinderProcess, 5);
+    ClassDefOverride(TRestRawPeaksFinderProcess, 6);
 };
 
 #endif  // REST_TRESTRAWPEAKSFINDERPROCESS_H

--- a/src/TRestRawPeaksFinderProcess.cxx
+++ b/src/TRestRawPeaksFinderProcess.cxx
@@ -50,7 +50,7 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
         // Choose appropriate function based on channel type
         if (channelType == "tpc") {
             signal->CalculateBaseLine(fBaselineRange.X(), fBaselineRange.Y());
-            
+
             double baseline = signal->GetBaseLine();
             double baselinesigma = signal->GetBaseLineSigma();
 
@@ -83,8 +83,7 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
         if (channelType == "tpc") {
             signal->CalculateBaseLine(fBaselineRange.X(), fBaselineRange.Y());
 
-            const auto peaks =
-                signal->GetPeaks(BaseLineMean + 10 * BaseLineSigmaMean, fDistance);
+            const auto peaks = signal->GetPeaks(BaseLineMean + 10 * BaseLineSigmaMean, fDistance);
 
             for (const auto& [time, amplitude] : peaks) {
                 eventPeaks.emplace_back(signalId, time, amplitude);

--- a/src/TRestRawPeaksFinderProcess.cxx
+++ b/src/TRestRawPeaksFinderProcess.cxx
@@ -81,9 +81,8 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
 
             // I think count will never be 0, just in case
             const double threshold =
-                (countTPC > 0)
-                    ? BaseLineMean + fSigmaOverBaseline * BaseLineSigmaMean
-                    : signal->GetBaseLine() + fSigmaOverBaseline * signal->GetBaseLineSigma();
+                (countTPC > 0) ? BaseLineMean + fSigmaOverBaseline * BaseLineSigmaMean
+                               : signal->GetBaseLine() + fSigmaOverBaseline * signal->GetBaseLineSigma();
             if (countTPC <= 0) {
                 cerr << "TRestRawPeaksFinderProcess::ProcessEvent: TPC count is 0 in TPC loop, this should "
                         "not happen"

--- a/src/TRestRawPeaksFinderProcess.cxx
+++ b/src/TRestRawPeaksFinderProcess.cxx
@@ -82,8 +82,9 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
             constexpr double numberOfBaselinesThreshold = 10;
             // I think count will never be 0, just in case
             const double threshold =
-                (countTPC > 0) ? BaseLineMean + numberOfBaselinesThreshold * BaseLineSigmaMean
-                            : signal->GetBaseLine() + numberOfBaselinesThreshold * signal->GetBaseLineSigma();
+                (countTPC > 0)
+                    ? BaseLineMean + numberOfBaselinesThreshold * BaseLineSigmaMean
+                    : signal->GetBaseLine() + numberOfBaselinesThreshold * signal->GetBaseLineSigma();
             if (countTPC <= 0) {
                 cerr << "TRestRawPeaksFinderProcess::ProcessEvent: TPC count is 0 in TPC loop, this should "
                         "not happen"

--- a/src/TRestRawPeaksFinderProcess.cxx
+++ b/src/TRestRawPeaksFinderProcess.cxx
@@ -364,11 +364,11 @@ void TRestRawPeaksFinderProcess::InitFromConfigFile() {
         // if no channel type is specified, use all channel types
     }
 
-    fThresholdOverBaseline = StringToDouble(GetParameter("thresholdOverBaseline", fThresholdOverBaseline));
-    fSigmaOverBaseline = StringToDouble(GetParameter("sigmaOverBaseline", fSigmaOverBaseline));
+    fThresholdOverBaseline = GetDblParameterWithUnits("thresholdOverBaseline", fThresholdOverBaseline);
+    fSigmaOverBaseline = GetDblParameterWithUnits("sigmaOverBaseline", fSigmaOverBaseline);
     fBaselineRange = Get2DVectorParameterWithUnits("baselineRange", fBaselineRange);
-    fDistance = StringToDouble(GetParameter("distance", fDistance));
-    fWindow = StringToDouble(GetParameter("window", fWindow));
+    fDistance = UShort_t(GetDblParameterWithUnits("distance", fDistance));
+    fWindow = UShort_t(GetDblParameterWithUnits("window", fWindow));
     fRemoveAllVetoes = StringToBool(GetParameter("removeAllVetoes", fRemoveAllVetoes));
     fRemovePeaklessVetoes = StringToBool(GetParameter("removePeaklessVetoes", fRemovePeaklessVetoes));
 

--- a/src/TRestRawPeaksFinderProcess.cxx
+++ b/src/TRestRawPeaksFinderProcess.cxx
@@ -369,8 +369,8 @@ void TRestRawPeaksFinderProcess::InitFromConfigFile() {
     fBaselineRange = Get2DVectorParameterWithUnits("baselineRange", fBaselineRange);
     fDistance = StringToDouble(GetParameter("distance", fDistance));
     fWindow = StringToDouble(GetParameter("window", fWindow));
-    fRemoveAllVetoes = StringToBool(GetParameter("removeAllVetos", fRemoveAllVetoes));
-    fRemovePeaklessVetoes = StringToBool(GetParameter("removePeaklessVetos", fRemovePeaklessVetoes));
+    fRemoveAllVetoes = StringToBool(GetParameter("removeAllVetoes", fRemoveAllVetoes));
+    fRemovePeaklessVetoes = StringToBool(GetParameter("removePeaklessVetoes", fRemovePeaklessVetoes));
 
     fTimeBinToTimeFactorMultiplier = GetDblParameterWithUnits("sampling", fTimeBinToTimeFactorMultiplier);
     fTimeBinToTimeFactorOffset = GetDblParameterWithUnits("trigDelay", fTimeBinToTimeFactorOffset);
@@ -415,7 +415,7 @@ void TRestRawPeaksFinderProcess::InitFromConfigFile() {
 
     if (filterType != "veto" && fRemovePeaklessVetoes) {
         cerr << "TRestRawPeaksFinderProcess::InitProcess: removing veto signals only makes sense when the "
-                "process is applied to veto signals. Remove \"removePeaklessVetos\" parameter"
+                "process is applied to veto signals. Remove \"removePeaklessVetoes\" parameter"
              << endl;
         exit(1);
     }

--- a/src/TRestRawSignal.cxx
+++ b/src/TRestRawSignal.cxx
@@ -987,7 +987,7 @@ vector<pair<UShort_t, double>> TRestRawSignal::GetPeaks(double threshold, UShort
                     double maxAmplitude = smoothedValues[i];
 
                     // Look ahead within the specified distance to find the bin with the maximum amplitude
-                    for (int j = i + 1; j <= i + distance && j < smoothedValues.size(); ++j) {
+                    for (std::vector<double>::size_type j = i + 1; j <= i + distance && j < smoothedValues.size(); ++j) {
                         if (smoothedValues[j] > maxAmplitude) {
                             maxAmplitude = smoothedValues[j];
                             maxBin = j;

--- a/src/TRestRawSignal.cxx
+++ b/src/TRestRawSignal.cxx
@@ -987,7 +987,8 @@ vector<pair<UShort_t, double>> TRestRawSignal::GetPeaks(double threshold, UShort
                     double maxAmplitude = smoothedValues[i];
 
                     // Look ahead within the specified distance to find the bin with the maximum amplitude
-                    for (std::vector<double>::size_type j = i + 1; j <= i + distance && j < smoothedValues.size(); ++j) {
+                    for (std::vector<double>::size_type j = i + 1;
+                         j <= i + distance && j < smoothedValues.size(); ++j) {
                         if (smoothedValues[j] > maxAmplitude) {
                             maxAmplitude = smoothedValues[j];
                             maxBin = j;

--- a/src/TRestRawSignal.cxx
+++ b/src/TRestRawSignal.cxx
@@ -264,12 +264,15 @@ void TRestRawSignal::InitializePointsOverThreshold(const TVector2& thrPar, Int_t
             if (pulse.size() >= (unsigned int)nPointsOver) {
                 // auto stdev = TMath::StdDev(begin(pulse), end(pulse));
                 // calculate stdev
-                double mean = std::accumulate(pulse.begin(), pulse.end(), 0.0) / pulse.size();
+                double mean = std::accumulate(pulse.begin(), pulse.end(), 0.0) / double(pulse.size());
                 double sq_sum = std::inner_product(pulse.begin(), pulse.end(), pulse.begin(), 0.0);
-                double stdev = std::sqrt(sq_sum / pulse.size() - mean * mean);
+                double stdev = std::sqrt(sq_sum / double(pulse.size()) - mean * mean);
 
-                if (stdev > signalTh * fBaseLineSigma)
-                    for (int j = pos; j < i; j++) fPointsOverThreshold.push_back(j);
+                if (stdev > signalTh * fBaseLineSigma) {
+                    for (int j = pos; j < i; j++) {
+                        fPointsOverThreshold.push_back(j);
+                    }
+                }
             }
         }
     }
@@ -283,14 +286,18 @@ void TRestRawSignal::InitializePointsOverThreshold(const TVector2& thrPar, Int_t
 /// of fThresholdIntegral. This method is only used internally.
 ///
 void TRestRawSignal::CalculateThresholdIntegral() {
-    if (fRange.X() < 0) fRange.SetX(0);
-    if (fRange.Y() <= 0 || fRange.Y() > GetNumberOfPoints()) fRange.SetY(GetNumberOfPoints());
+    if (fRange.X() < 0) {
+        fRange.SetX(0);
+    }
+    if (fRange.Y() <= 0 || fRange.Y() > GetNumberOfPoints()) {
+        fRange.SetY(GetNumberOfPoints());
+    }
 
     fThresholdIntegral = 0;
 
-    for (unsigned int n = 0; n < fPointsOverThreshold.size(); n++) {
-        if (fPointsOverThreshold[n] >= fRange.X() && fPointsOverThreshold[n] < fRange.Y()) {
-            fThresholdIntegral += GetData(fPointsOverThreshold[n]);
+    for (int n : fPointsOverThreshold) {
+        if (n >= fRange.X() && n < fRange.Y()) {
+            fThresholdIntegral += GetData(n);
         }
     }
 }
@@ -301,11 +308,17 @@ void TRestRawSignal::CalculateThresholdIntegral() {
 /// the integral is calculated in the full range.
 ///
 Double_t TRestRawSignal::GetIntegral() {
-    if (fRange.X() < 0) fRange.SetX(0);
-    if (fRange.Y() <= 0 || fRange.Y() > GetNumberOfPoints()) fRange.SetY(GetNumberOfPoints());
+    if (fRange.X() < 0) {
+        fRange.SetX(0);
+    }
+    if (fRange.Y() <= 0 || fRange.Y() > GetNumberOfPoints()) {
+        fRange.SetY(GetNumberOfPoints());
+    }
 
     Double_t sum = 0;
-    for (int i = fRange.X(); i < fRange.Y(); i++) sum += GetData(i);
+    for (int i = fRange.X(); i < fRange.Y(); i++) {
+        sum += GetData(i);
+    }
     return sum;
 }
 
@@ -314,11 +327,17 @@ Double_t TRestRawSignal::GetIntegral() {
 /// by (startBin,endBin).
 ///
 Double_t TRestRawSignal::GetIntegralInRange(Int_t startBin, Int_t endBin) {
-    if (startBin < 0) startBin = 0;
-    if (endBin <= 0 || endBin > GetNumberOfPoints()) endBin = GetNumberOfPoints();
+    if (startBin < 0) {
+        startBin = 0;
+    }
+    if (endBin <= 0 || endBin > GetNumberOfPoints()) {
+        endBin = GetNumberOfPoints();
+    }
 
     Double_t sum = 0;
-    for (int i = startBin; i < endBin; i++) sum += GetRawData(i);
+    for (int i = startBin; i < endBin; i++) {
+        sum += GetRawData(i);
+    }
     return sum;
 }
 
@@ -328,7 +347,7 @@ Double_t TRestRawSignal::GetIntegralInRange(Int_t startBin, Int_t endBin) {
 /// have been called first.
 ///
 Double_t TRestRawSignal::GetThresholdIntegral() {
-    if (fThresholdIntegral == -1)
+    if (fThresholdIntegral == -1) {
         if (fShowWarnings) {
             std::cout << "TRestRawSignal::GetThresholdIntegral. "
                          "InitializePointsOverThreshold should be "
@@ -336,6 +355,7 @@ Double_t TRestRawSignal::GetThresholdIntegral() {
                       << endl;
             fShowWarnings = false;
         }
+    }
     return fThresholdIntegral;
 }
 
@@ -917,7 +937,9 @@ vector<pair<UShort_t, double>> TRestRawSignal::GetPeaks(double threshold, UShort
         10;  // Region to compare for peak/no peak classification. 10 means 5 bins to each side
     const size_t numPoints = GetNumberOfPoints();
 
-    if (numPoints == 0) return peaks;
+    if (numPoints == 0) {
+        return peaks;
+    }
 
     // Pre-calculate smoothed values for all bins using a rolling sum
     vector<double> smoothedValues(numPoints, 0.0);
@@ -1002,7 +1024,7 @@ vector<pair<UShort_t, double>> TRestRawSignal::GetPeaks(double threshold, UShort
                     double peakAmplitude = (amplitude1 + amplitude2 + amplitude3) / 3.0;
 
                     // Store the peak position and amplitude
-                    peaks.push_back(std::make_pair(maxBin, peakAmplitude));
+                    peaks.emplace_back(maxBin, peakAmplitude);
                 }
             }
         }

--- a/src/TRestRawSignal.cxx
+++ b/src/TRestRawSignal.cxx
@@ -977,30 +977,31 @@ vector<pair<UShort_t, double>> TRestRawSignal::GetPeaks(double threshold, UShort
             }
 
             // If it's a peak and it´s above the threshold and further than distance to the previous peak, add
-            // to peaks
+            // to peaks the biggest amplitude bin within the next "distance" bins and as amplitude the TripleMaxAverage.
+            // This is because for flat regions the detected peak is more to the left than the actual one.
             if (isPeak && smoothedValue > threshold) {
                 if (peaks.empty() || i - peaks.back().first >= distance) {
-                    double fitMinRange = i - 20;
-                    double fitMaxRange = i + 20;
-
-                    // Create a Gaussian fit function
-                    TF1 fitFunction("gaussianFit", "gaus", fitMinRange, fitMaxRange);
-                    // Fit the data with the Gaussian function
-                    fitFunction.SetRange(fitMinRange, fitMaxRange);  // Initial parameters
-
-                    // Create histogram with the values to fit
-                    TH1D histogram("hist", "hist", 40, fitMinRange, fitMaxRange);
-                    for (int k = i - 20; k <= i + 20; ++k) {
-                        histogram.SetBinContent(k - (i - 20) + 1, GetRawData(k));  // Set bin content
+                    
+                    // Initialize variables to find the max amplitude within the next "distance" bins
+                    int maxBin = i;
+                    double maxAmplitude = smoothedValues[i];
+                    
+                    // Look ahead within the specified distance to find the bin with the maximum amplitude
+                    for (int j = i + 1; j <= i + distance && j < smoothedValues.size(); ++j) {
+                        if (smoothedValues[j] > maxAmplitude) {
+                            maxAmplitude = smoothedValues[j];
+                            maxBin = j;
+                        }
                     }
-                    histogram.Fit(&fitFunction, "RQ");
-
-                    // Get peak position and amplitude from the fit
-                    double peakPosition = fitFunction.GetParameter(1);
-                    UShort_t formattedPeakPosition = static_cast<UShort_t>(peakPosition);
-                    double peakAmplitude = GetRawData(formattedPeakPosition);
-
-                    peaks.push_back(std::make_pair(formattedPeakPosition, peakAmplitude));
+                    
+                    // Calculate the peak amplitude as the average of maxBin and its two neighbors
+                    double amplitude1 = GetRawData(maxBin - 1);
+                    double amplitude2 = GetRawData(maxBin);
+                    double amplitude3 = GetRawData(maxBin + 1);
+                    double peakAmplitude = (amplitude1 + amplitude2 + amplitude3) / 3.0;
+                    
+                    // Store the peak position and amplitude
+                    peaks.push_back(std::make_pair(maxBin, peakAmplitude));
                 }
             }
         }

--- a/src/TRestRawSignal.cxx
+++ b/src/TRestRawSignal.cxx
@@ -977,15 +977,15 @@ vector<pair<UShort_t, double>> TRestRawSignal::GetPeaks(double threshold, UShort
             }
 
             // If it's a peak and it´s above the threshold and further than distance to the previous peak, add
-            // to peaks the biggest amplitude bin within the next "distance" bins and as amplitude the TripleMaxAverage.
-            // This is because for flat regions the detected peak is more to the left than the actual one.
+            // to peaks the biggest amplitude bin within the next "distance" bins and as amplitude the
+            // TripleMaxAverage. This is because for flat regions the detected peak is more to the left than
+            // the actual one.
             if (isPeak && smoothedValue > threshold) {
                 if (peaks.empty() || i - peaks.back().first >= distance) {
-                    
                     // Initialize variables to find the max amplitude within the next "distance" bins
                     int maxBin = i;
                     double maxAmplitude = smoothedValues[i];
-                    
+
                     // Look ahead within the specified distance to find the bin with the maximum amplitude
                     for (int j = i + 1; j <= i + distance && j < smoothedValues.size(); ++j) {
                         if (smoothedValues[j] > maxAmplitude) {
@@ -993,13 +993,13 @@ vector<pair<UShort_t, double>> TRestRawSignal::GetPeaks(double threshold, UShort
                             maxBin = j;
                         }
                     }
-                    
+
                     // Calculate the peak amplitude as the average of maxBin and its two neighbors
                     double amplitude1 = GetRawData(maxBin - 1);
                     double amplitude2 = GetRawData(maxBin);
                     double amplitude3 = GetRawData(maxBin + 1);
                     double peakAmplitude = (amplitude1 + amplitude2 + amplitude3) / 3.0;
-                    
+
                     // Store the peak position and amplitude
                     peaks.push_back(std::make_pair(maxBin, peakAmplitude));
                 }


### PR DESCRIPTION
A new option to calculate the baseline excluding outliers is added. 

It will calculate the median and standard deviation of a signal in the selected range considering only the 25-75% values, excluding big and small outliers. This might be important when calculating the VETO peaks, for example, as it uses the BaseLine (+ input threshold) to exclude small peaks. 

If there are peaks (or negative regions) in the interval to calculate the sigma they will lead to a biased BaseLine. If there are many peaks, for example, the calculated BaseLine will be biased to bigger values and might eliminate clear peaks. 
By calculating the BaseLine without the outliers (the peaks will be in the >75% region) the calculated value will be more precise.
