### PR TITLE
Calculate veto signals baseline without outliers

### DIFF
--- a/inc/TRestRawSignal.h
+++ b/inc/TRestRawSignal.h
@@ -41,6 +41,8 @@ class TRestRawSignal {
 
     void CalculateBaseLineSigmaIQR(Int_t startBin, Int_t endBin);
 
+    void CalculateBaseLineSigmaExcludeOutliers(Int_t startBin, Int_t endBin);
+
     std::vector<Float_t> GetSignalSmoothed_ExcludeOutliers(Int_t averagingPoints);
 
    protected:
@@ -197,6 +199,8 @@ class TRestRawSignal {
     void CalculateBaseLineMean(Int_t startBin, Int_t endBin);
 
     void CalculateBaseLineMedian(Int_t startBin, Int_t endBin);
+
+    void CalculateBaseLineMedianExcludeOutliers(Int_t startBin, Int_t endBin);
 
     void CalculateBaseLine(Int_t startBin, Int_t endBin, const std::string& option = "");
 

--- a/src/TRestRawPeaksFinderProcess.cxx
+++ b/src/TRestRawPeaksFinderProcess.cxx
@@ -97,7 +97,7 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
         } else if (channelType == "veto") {
             // For veto signals the baseline is calculated over the whole range, as we don´t know where the
             // signal will be.
-            signal->CalculateBaseLine(0, 511, "robust");
+            signal->CalculateBaseLine(0, 511, "OUTLIERS");
             // For veto signals the threshold is selected by the user.
             const auto peaks =
                 signal->GetPeaksVeto(signal->GetBaseLine() + fThresholdOverBaseline, fDistance);


### PR DESCRIPTION

A new option to calculate the baseline excluding outliers is added.

It will calculate the median and standard deviation of a signal in the selected range considering only the 25-75% values, excluding big and small outliers. This might be important when calculating the VETO peaks, for example, as it uses the BaseLine (+ input threshold) to exclude small peaks.

If there are peaks (or negative regions) in the interval to calculate the sigma they will lead to a biased BaseLine. If there are many peaks, for example, the calculated BaseLine will be biased to bigger values and might eliminate clear peaks.
By calculating the BaseLine without the outliers (the peaks will be in the >75% region) the calculated value will be more precise.
