### PR TITLE
Fix TRestRawFeminosRootToSignalProcess setting a wrong timestamp

### DIFF
--- a/src/TRestRawFeminosRootToSignalProcess.cxx
+++ b/src/TRestRawFeminosRootToSignalProcess.cxx
@@ -123,8 +123,8 @@ TRestEvent* TRestRawFeminosRootToSignalProcess::ProcessEvent(TRestEvent* inputEv
 
     fSignalEvent->SetID(fInputTreeEntry);
 
-    // TODO: double check this is correct
-    fSignalEvent->SetTime(fInputEventTreeTimestamp / 1000, fInputEventTreeTimestamp % 1000);
+    // fInputEventTreeTimestamp is in milliseconds and TRestEvent::SetTime(seconds, nanoseconds)
+    fSignalEvent->SetTime(fInputEventTreeTimestamp / 1000, fInputEventTreeTimestamp % 1000 *1000000);
 
     for (size_t i = 0; i < fInputEventTreeSignalIds->size(); i++) {
         auto signal = TRestRawSignal();

--- a/src/TRestRawFeminosRootToSignalProcess.cxx
+++ b/src/TRestRawFeminosRootToSignalProcess.cxx
@@ -124,7 +124,7 @@ TRestEvent* TRestRawFeminosRootToSignalProcess::ProcessEvent(TRestEvent* inputEv
     fSignalEvent->SetID(fInputTreeEntry);
 
     // fInputEventTreeTimestamp is in milliseconds and TRestEvent::SetTime(seconds, nanoseconds)
-    fSignalEvent->SetTime(fInputEventTreeTimestamp / 1000, fInputEventTreeTimestamp % 1000 *1000000);
+    fSignalEvent->SetTime(fInputEventTreeTimestamp / 1000, fInputEventTreeTimestamp % 1000 * 1000000);
 
     for (size_t i = 0; i < fInputEventTreeSignalIds->size(); i++) {
         auto signal = TRestRawSignal();


### PR DESCRIPTION
![AlvaroEzq](https://badgen.net/badge/PR%20submitted%20by%3A/AlvaroEzq/blue) ![Ok: 2](https://badgen.net/badge/PR%20Size/Ok%3A%202/green) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/alvaroezq_fixRootToSignal/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/alvaroezq_fixRootToSignal) [![](https://github.com/rest-for-physics/rawlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=alvaroezq_fixRootToSignal)](https://github.com/rest-for-physics/rawlib/commits/alvaroezq_fixRootToSignal) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

PR to fix issue #149

The timestamp of the event is not set correctly in this line:
https://github.com/rest-for-physics/rawlib/blob/a4ba0c1c6cdcf62638212cdd5489206532372a2c/src/TRestRawFeminosRootToSignalProcess.cxx#L126-L127
This is due to the fInputEventTreeTimestamp being in [milliseconds](https://github.com/rest-for-physics/feminos-daq/blob/9fbd3812be93a399845a97531fd8ae043373e44b/src/root/storage.cpp#L115-L116) and the method [TRestEvent::SetTime](https://github.com/rest-for-physics/framework/blob/39b457ec8411fce294e3d46f0d2c33d9a4d78864/source/framework/core/inc/TRestEvent.h#L64) second parameter is nanoseconds. So the subsecond information of the timestamp is not correct. This is solved easily by just changing that line to 
`fSignalEvent->SetTime(fInputEventTreeTimestamp / 1000, fInputEventTreeTimestamp % 1000 * 1.e6);`