### PR TITLE
Add observables with amplitude corrected by baseline

### DIFF
--- a/inc/TRestRawSignal.h
+++ b/inc/TRestRawSignal.h
@@ -30,8 +30,8 @@
 
 #include <iostream>
 #include <string>
-#include <vector>
 #include <tuple>
+#include <vector>
 
 //! It defines a Short_t array with a physical parameter that evolves in time using a fixed time bin.
 class TRestRawSignal {
@@ -224,8 +224,10 @@ class TRestRawSignal {
     /// Returns the (time, amplitude) of the peaks in the signal.
     /// Peaks are defined as the points that are above the threshold and are separated by a minimum distance
     /// in time bin units. The threshold must be set in absolute value (regardless of the baseline)
-    std::vector<std::tuple<double, UShort_t, double>> GetPeaks(double threshold, UShort_t distance = 5, double signalBaseLine = 0.0) const;
-    std::vector<std::tuple<double, UShort_t, double>> GetPeaksVeto(double threshold, UShort_t distance = 5, double signalBaseLine = 0.0) const;
+    std::vector<std::tuple<double, UShort_t, double>> GetPeaks(double threshold, UShort_t distance = 5,
+                                                               double signalBaseLine = 0.0) const;
+    std::vector<std::tuple<double, UShort_t, double>> GetPeaksVeto(double threshold, UShort_t distance = 5,
+                                                                   double signalBaseLine = 0.0) const;
 
     TRestRawSignal();
     TRestRawSignal(Int_t nBins);

--- a/inc/TRestRawSignal.h
+++ b/inc/TRestRawSignal.h
@@ -31,6 +31,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <tuple>
 
 //! It defines a Short_t array with a physical parameter that evolves in time using a fixed time bin.
 class TRestRawSignal {
@@ -223,13 +224,13 @@ class TRestRawSignal {
     /// Returns the (time, amplitude) of the peaks in the signal.
     /// Peaks are defined as the points that are above the threshold and are separated by a minimum distance
     /// in time bin units. The threshold must be set in absolute value (regardless of the baseline)
-    std::vector<std::pair<UShort_t, double>> GetPeaks(double threshold, UShort_t distance = 5) const;
-    std::vector<std::pair<UShort_t, double>> GetPeaksVeto(double threshold, UShort_t distance = 5) const;
+    std::vector<std::tuple<double, UShort_t, double>> GetPeaks(double threshold, UShort_t distance = 5, double signalBaseLine = 0.0) const;
+    std::vector<std::tuple<double, UShort_t, double>> GetPeaksVeto(double threshold, UShort_t distance = 5, double signalBaseLine = 0.0) const;
 
     TRestRawSignal();
     TRestRawSignal(Int_t nBins);
     ~TRestRawSignal();
 
-    ClassDef(TRestRawSignal, 2);
+    ClassDef(TRestRawSignal, 3);
 };
 #endif

--- a/src/TRestRawPeaksFinderProcess.cxx
+++ b/src/TRestRawPeaksFinderProcess.cxx
@@ -28,7 +28,8 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
         exit(1);
     }
 
-    vector<tuple<UShort_t, UShort_t, double, double>> eventPeaks;  // signalId, time, amplitude, amplitudeBaseLineCorrected
+    vector<tuple<UShort_t, UShort_t, double, double>>
+        eventPeaks;  // signalId, time, amplitude, amplitudeBaseLineCorrected
 
     // Calculate average baseline and sigma of all the TPC signals
     double BaseLineMean = 0.0;
@@ -82,8 +83,9 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
 
             // I think count will never be 0, just in case
             if (countTPC <= 0) {
-                cerr << "TRestRawPeaksFinderProcess::ProcessEvent: TPC count is 0 in TPC loop, this should not happen"
-                    << endl;
+                cerr << "TRestRawPeaksFinderProcess::ProcessEvent: TPC count is 0 in TPC loop, this should "
+                        "not happen"
+                     << endl;
                 exit(1);
             }
 
@@ -110,7 +112,8 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
 
     // sort eventPeaks by time, then signal id
     sort(eventPeaks.begin(), eventPeaks.end(),
-         [](const tuple<UShort_t, UShort_t, double, double>& a, const tuple<UShort_t, UShort_t, double, double>& b) {
+         [](const tuple<UShort_t, UShort_t, double, double>& a,
+            const tuple<UShort_t, UShort_t, double, double>& b) {
              return tie(get<1>(a), get<0>(a)) < tie(get<1>(b), get<0>(b));
          });
 
@@ -175,7 +178,8 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
 
         // add the peaks that are in the window
         for (size_t otherPeakIndex = peakIndex + 1; otherPeakIndex < eventPeaks.size(); otherPeakIndex++) {
-            const auto& [otherChannelId, otherTime, otherAmplitude, otherAmplitudeBaseLineCorrected] = eventPeaks[otherPeakIndex];
+            const auto& [otherChannelId, otherTime, otherAmplitude, otherAmplitudeBaseLineCorrected] =
+                eventPeaks[otherPeakIndex];
 
             if (otherTime < windowTimeStart) {
                 continue;

--- a/src/TRestRawPeaksFinderProcess.cxx
+++ b/src/TRestRawPeaksFinderProcess.cxx
@@ -28,7 +28,7 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
         exit(1);
     }
 
-    vector<tuple<UShort_t, UShort_t, double>> eventPeaks;  // signalId, time, amplitude
+    vector<tuple<UShort_t, UShort_t, double, double>> eventPeaks;  // signalId, time, amplitude, amplitudeBaseLineCorrected
 
     // Calculate average baseline and sigma of all the TPC signals
     double BaseLineMean = 0.0;
@@ -78,57 +78,61 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
         // Choose appropriate function based on channel type
         if (channelType == "tpc") {
             signal->CalculateBaseLine(fBaselineRange.X(), fBaselineRange.Y());
+            double signalBaseLine = signal->GetBaseLine();
 
             // I think count will never be 0, just in case
-            const double threshold =
-                (countTPC > 0) ? BaseLineMean + fSigmaOverBaseline * BaseLineSigmaMean
-                               : signal->GetBaseLine() + fSigmaOverBaseline * signal->GetBaseLineSigma();
             if (countTPC <= 0) {
-                cerr << "TRestRawPeaksFinderProcess::ProcessEvent: TPC count is 0 in TPC loop, this should "
-                        "not happen"
-                     << endl;
+                cerr << "TRestRawPeaksFinderProcess::ProcessEvent: TPC count is 0 in TPC loop, this should not happen"
+                    << endl;
                 exit(1);
             }
-            const auto peaks = signal->GetPeaks(threshold, fDistance);
 
-            for (const auto& [time, amplitude] : peaks) {
-                eventPeaks.emplace_back(signalId, time, amplitude);
+            const double threshold = BaseLineMean + fSigmaOverBaseline * BaseLineSigmaMean;
+            const auto peaks = signal->GetPeaks(threshold, fDistance, signalBaseLine);
+
+            for (const auto& [time, amplitude, amplitudeBaseLineCorrected] : peaks) {
+                eventPeaks.emplace_back(signalId, time, amplitude, amplitudeBaseLineCorrected);
             }
         } else if (channelType == "veto") {
             // For veto signals the baseline is calculated over the whole range, as we don´t know where the
             // signal will be.
             signal->CalculateBaseLine(0, 511, "OUTLIERS");
+            double signalBaseLine = signal->GetBaseLine();
             // For veto signals the threshold is selected by the user.
             const auto peaks =
-                signal->GetPeaksVeto(signal->GetBaseLine() + fThresholdOverBaseline, fDistance);
+                signal->GetPeaksVeto(signalBaseLine + fThresholdOverBaseline, fDistance, signalBaseLine);
 
-            for (const auto& [time, amplitude] : peaks) {
-                eventPeaks.emplace_back(signalId, time, amplitude);
+            for (const auto& [time, amplitude, amplitudeBaseLineCorrected] : peaks) {
+                eventPeaks.emplace_back(signalId, time, amplitude, amplitudeBaseLineCorrected);
             }
         }
     }
 
     // sort eventPeaks by time, then signal id
     sort(eventPeaks.begin(), eventPeaks.end(),
-         [](const tuple<UShort_t, UShort_t, double>& a, const tuple<UShort_t, UShort_t, double>& b) {
+         [](const tuple<UShort_t, UShort_t, double, double>& a, const tuple<UShort_t, UShort_t, double, double>& b) {
              return tie(get<1>(a), get<0>(a)) < tie(get<1>(b), get<0>(b));
          });
 
     vector<UShort_t> peaksChannelId;
     vector<UShort_t> peaksTime;
     vector<double> peaksAmplitude;
+    vector<double> peaksAmplitudeBaseLineCorrected;
 
     double peaksEnergy = 0.0;
+    double peaksEnergyBaseLineCorrected = 0.0;
     UShort_t peaksCount = 0;
     UShort_t peaksCountUnique = 0;
 
     set<UShort_t> uniquePeaks;
-    for (const auto& [channelId, time, amplitude] : eventPeaks) {
+    for (const auto& [channelId, time, amplitude, amplitudeBaseLineCorrected] : eventPeaks) {
         peaksChannelId.push_back(channelId);
         peaksTime.push_back(time);
         peaksAmplitude.push_back(amplitude);
+        peaksAmplitudeBaseLineCorrected.push_back(amplitudeBaseLineCorrected);
 
         peaksEnergy += amplitude;
+        peaksEnergyBaseLineCorrected += amplitudeBaseLineCorrected;
         peaksCount++;
 
         if (uniquePeaks.find(channelId) == uniquePeaks.end()) {
@@ -140,8 +144,10 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("peaksChannelId", peaksChannelId);
     SetObservableValue("peaksTimeBin", peaksTime);
     SetObservableValue("peaksAmplitudeADC", peaksAmplitude);
+    SetObservableValue("peaksAmplitudeBaseLineCorrectedADC", peaksAmplitudeBaseLineCorrected);
 
     SetObservableValue("peaksAmplitudeADCSum", peaksEnergy);
+    SetObservableValue("peaksAmplitudeBaseLineCorrectedADCSum", peaksEnergyBaseLineCorrected);
     SetObservableValue("peaksCount", peaksCount);
     SetObservableValue("peaksCountUnique", peaksCountUnique);
 
@@ -151,7 +157,7 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
 
     UShort_t window_index = 0;
     for (size_t peakIndex = 0; peakIndex < eventPeaks.size(); peakIndex++) {
-        const auto& [channelId, time, amplitude] = eventPeaks[peakIndex];
+        const auto& [channelId, time, amplitude, amplitudeBaseLineCorrected] = eventPeaks[peakIndex];
         const auto windowTimeStart = time - fWindow / 2;
         const auto windowTimeEnd = time + fWindow / 2;
 
@@ -169,7 +175,7 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
 
         // add the peaks that are in the window
         for (size_t otherPeakIndex = peakIndex + 1; otherPeakIndex < eventPeaks.size(); otherPeakIndex++) {
-            const auto& [otherChannelId, otherTime, otherAmplitude] = eventPeaks[otherPeakIndex];
+            const auto& [otherChannelId, otherTime, otherAmplitude, otherAmplitudeBaseLineCorrected] = eventPeaks[otherPeakIndex];
 
             if (otherTime < windowTimeStart) {
                 continue;
@@ -250,13 +256,13 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
     }
 
     if (fADCtoEnergyFactor != 0.0 || !fChannelIDToADCtoEnergyFactor.empty()) {
-        vector<Double_t> peaksEnergyPhysical(peaksAmplitude.size(), 0.0);
+        vector<Double_t> peaksEnergyPhysical(peaksAmplitudeBaseLineCorrected.size(), 0.0);
         Double_t peaksEnergySum = 0.0;
 
         if (fADCtoEnergyFactor != 0.0) {
             // same factor for all peaks
             for (size_t i = 0; i < peaksAmplitude.size(); i++) {
-                peaksEnergyPhysical[i] = peaksAmplitude[i] * fADCtoEnergyFactor;
+                peaksEnergyPhysical[i] = peaksAmplitudeBaseLineCorrected[i] * fADCtoEnergyFactor;
                 peaksEnergySum += peaksEnergyPhysical[i];
             }
         } else {
@@ -271,7 +277,7 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
                 }
                 const auto factor = fChannelIDToADCtoEnergyFactor[channelId];
 
-                peaksEnergyPhysical[i] = peaksAmplitude[i] * factor;
+                peaksEnergyPhysical[i] = peaksAmplitudeBaseLineCorrected[i] * factor;
                 peaksEnergySum += peaksEnergyPhysical[i];
             }
         }
@@ -283,7 +289,7 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
     // Remove peak-less veto signals after the peak finding if chosen
     if (fRemovePeaklessVetoes && !fRemoveAllVetoes) {
         set<UShort_t> peakSignalIds;
-        for (const auto& [channelId, time, amplitude] : eventPeaks) {
+        for (const auto& [channelId, time, amplitude, amplitudeBaseLineCorrected] : eventPeaks) {
             peakSignalIds.insert(channelId);
         }
 

--- a/src/TRestRawSignal.cxx
+++ b/src/TRestRawSignal.cxx
@@ -1026,7 +1026,9 @@ TGraph* TRestRawSignal::GetGraph(Int_t color) {
     return fGraph;
 }
 
-std::vector<std::tuple<double, UShort_t, double>> TRestRawSignal::GetPeaks(double threshold, UShort_t distance, double signalBaseLine) const {
+std::vector<std::tuple<double, UShort_t, double>> TRestRawSignal::GetPeaks(double threshold,
+                                                                           UShort_t distance,
+                                                                           double signalBaseLine) const {
     std::vector<std::tuple<double, UShort_t, double>> peaks;
 
     const UShort_t smoothingWindow =
@@ -1130,7 +1132,9 @@ std::vector<std::tuple<double, UShort_t, double>> TRestRawSignal::GetPeaks(doubl
     return peaks;
 }
 
-std::vector<std::tuple<double, UShort_t, double>> TRestRawSignal::GetPeaksVeto(double threshold, UShort_t distance, double signalBaseLine) const {
+std::vector<std::tuple<double, UShort_t, double>> TRestRawSignal::GetPeaksVeto(double threshold,
+                                                                               UShort_t distance,
+                                                                               double signalBaseLine) const {
     std::vector<std::tuple<double, UShort_t, double>> peaks;
 
     const UShort_t smoothingWindow =

--- a/src/TRestRawSignal.cxx
+++ b/src/TRestRawSignal.cxx
@@ -1026,8 +1026,8 @@ TGraph* TRestRawSignal::GetGraph(Int_t color) {
     return fGraph;
 }
 
-vector<pair<UShort_t, double>> TRestRawSignal::GetPeaks(double threshold, UShort_t distance) const {
-    vector<pair<UShort_t, double>> peaks;
+std::vector<std::tuple<double, UShort_t, double>> TRestRawSignal::GetPeaks(double threshold, UShort_t distance, double signalBaseLine) const {
+    std::vector<std::tuple<double, UShort_t, double>> peaks;
 
     const UShort_t smoothingWindow =
         10;  // Region to compare for peak/no peak classification. 10 means 5 bins to each side
@@ -1099,7 +1099,7 @@ vector<pair<UShort_t, double>> TRestRawSignal::GetPeaks(double threshold, UShort
             // TripleMaxAverage. This is because for flat regions the detected peak is more to the left than
             // the actual one.
             if (isPeak && smoothedValue > threshold) {
-                if (peaks.empty() || i - peaks.back().first >= distance) {
+                if (peaks.empty() || i - std::get<0>(peaks.back()) >= distance) {
                     // Initialize variables to find the max amplitude within the next "distance" bins
                     int maxBin = i;
                     double maxAmplitude = smoothedValues[i];
@@ -1118,9 +1118,10 @@ vector<pair<UShort_t, double>> TRestRawSignal::GetPeaks(double threshold, UShort
                     double amplitude2 = GetRawData(maxBin);
                     double amplitude3 = GetRawData(maxBin + 1);
                     double peakAmplitude = (amplitude1 + amplitude2 + amplitude3) / 3.0;
+                    double peakAmplitudeBaseLineCorrected = peakAmplitude - signalBaseLine;
 
                     // Store the peak position and amplitude
-                    peaks.emplace_back(maxBin, peakAmplitude);
+                    peaks.emplace_back(maxBin, peakAmplitude, peakAmplitudeBaseLineCorrected);
                 }
             }
         }
@@ -1129,8 +1130,8 @@ vector<pair<UShort_t, double>> TRestRawSignal::GetPeaks(double threshold, UShort
     return peaks;
 }
 
-vector<pair<UShort_t, double>> TRestRawSignal::GetPeaksVeto(double threshold, UShort_t distance) const {
-    vector<pair<UShort_t, double>> peaks;
+std::vector<std::tuple<double, UShort_t, double>> TRestRawSignal::GetPeaksVeto(double threshold, UShort_t distance, double signalBaseLine) const {
+    std::vector<std::tuple<double, UShort_t, double>> peaks;
 
     const UShort_t smoothingWindow =
         4;  // Region to compare for peak/no peak classification. 10 means 5 bins to each side
@@ -1200,12 +1201,13 @@ vector<pair<UShort_t, double>> TRestRawSignal::GetPeaksVeto(double threshold, US
             // If it's a peak and it´s above the threshold and further than distance to the previous peak, add
             // to peaks
             if (isPeak && smoothedValue > threshold) {
-                if (peaks.empty() || i - peaks.back().first >= distance) {
+                if (peaks.empty() || i - std::get<0>(peaks.back()) >= distance) {
                     auto peakPosition = double(i);
                     auto formattedPeakPosition = static_cast<UShort_t>(peakPosition);
                     double peakAmplitude = GetRawData(formattedPeakPosition);
+                    double peakAmplitudeBaseLineCorrected = peakAmplitude - signalBaseLine;
 
-                    peaks.emplace_back(formattedPeakPosition, peakAmplitude);
+                    peaks.emplace_back(formattedPeakPosition, peakAmplitude, peakAmplitudeBaseLineCorrected);
                 }
             }
         }


### PR DESCRIPTION
![JPorron](https://badgen.net/badge/PR%20submitted%20by%3A/JPorron/blue) ![Ok: 41](https://badgen.net/badge/PR%20Size/Ok%3A%2041/green) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/jporron-PeaksFinder-addBaseLineCorrectedPeak/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/jporron-PeaksFinder-addBaseLineCorrectedPeak) [![](https://github.com/rest-for-physics/rawlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=jporron-PeaksFinder-addBaseLineCorrectedPeak)](https://github.com/rest-for-physics/rawlib/commits/jporron-PeaksFinder-addBaseLineCorrectedPeak) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Up to this, the PeaksFinderProcess uses the ADC amplitude of the peaks, but does not correct it substracting the baseline. Some changes are made to keep track of the baseline of each signal and substract it to the peak´s amplitude in order to better reconstruct the energy deposited.

Before:

![image](https://github.com/user-attachments/assets/455a724b-d5e3-44f6-a859-bd429d333e23)
![image](https://github.com/user-attachments/assets/6fb563f2-a3b8-4c5f-a317-76fba81b37ac)
_Fig 1: Observables for a given event before the change._

Now, the event is unaltered, but 2 new observables are added ("peaksAmplitudeBaseLineCorrectedADC" and "peaksAmplitudeBaseLineCorrectedADCSum"):

![image](https://github.com/user-attachments/assets/92948453-7df5-4920-ab6f-cf94b13a6dc2)
_Fig 2: Observables after the change._

These new observables take into account the baseline of each signal, calculated as the PeaksFinderProcess does for other capabilities: 

![image](https://github.com/user-attachments/assets/65f4821e-6298-4af7-beb0-36f98b05c67d)
_Fig 3: Calculation of the baseline for each signal._

As we can see, the "peaksAmplitudeBaseLineCorrectedADC" substracts the corresponding baseline:
3578-254=3324
3262-250=3012

Also, the "peaksEnergy", that uses the calibration factor, is now calculated with the corrected amplitude.