### PR TITLE
Update validation.yml to v4 of the artifact actions

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -59,7 +59,7 @@ jobs:
           branch: ${{ env.BRANCH_NAME }}
       - name: Cache framework installation
         id: rawlib-install-cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           key: ${{ env.BRANCH_NAME }}-${{ github.sha }}
           path: ${{ env.REST_PATH }}
@@ -77,7 +77,7 @@ jobs:
           repository: rest-for-physics/rawlib
           path: ${{ env.RAW_LIB_PATH }}
       - name: Restore cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: rawlib-install-cache
         with:
           key: ${{ env.BRANCH_NAME }}-${{ github.sha }}
@@ -133,7 +133,7 @@ jobs:
           repository: rest-for-physics/rawlib
           path: ${{ env.RAW_LIB_PATH }}
       - name: Restore cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: rawlib-install-cache
         with:
           key: ${{ env.BRANCH_NAME }}-${{ github.sha }}
@@ -157,7 +157,7 @@ jobs:
           repository: rest-for-physics/rawlib
           path: ${{ env.RAW_LIB_PATH }}
       - name: Restore cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: rawlib-install-cache
         with:
           key: ${{ env.BRANCH_NAME }}-${{ github.sha }}


### PR DESCRIPTION
![AlvaroEzq](https://badgen.net/badge/PR%20submitted%20by%3A/AlvaroEzq/blue) ![Ok: 4](https://badgen.net/badge/PR%20Size/Ok%3A%204/green) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/fixValidation/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/fixValidation) [![](https://github.com/rest-for-physics/rawlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=fixValidation)](https://github.com/rest-for-physics/rawlib/commits/fixValidation) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Since 30th January 2025 v3 of the artifact actions of github is deprecated and needs to be updated to v4. See [deprecation notice](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/).