### PR TITLE
Add a parameter to take into account the 0 time bin in simulations

### DIFF
--- a/inc/TRestRawPeaksFinderProcess.h
+++ b/inc/TRestRawPeaksFinderProcess.h
@@ -30,6 +30,7 @@ class TRestRawPeaksFinderProcess : public TRestEventProcess {
     /// \brief option to remove peak-less veto signals after finding the peaks
     Bool_t fRemovePeaklessVetoes = false;
 
+    UShort_t fSimulationZeroTimeBin = 210;
     Double_t fTimeBinToTimeFactorMultiplier = 0.0;
     Double_t fTimeBinToTimeFactorOffset = 0.0;
     Double_t fTimeBinToTimeFactorOffsetTCM = 0.0;
@@ -60,7 +61,7 @@ class TRestRawPeaksFinderProcess : public TRestEventProcess {
     TRestRawPeaksFinderProcess() = default;
     ~TRestRawPeaksFinderProcess() = default;
 
-    ClassDefOverride(TRestRawPeaksFinderProcess, 6);
+    ClassDefOverride(TRestRawPeaksFinderProcess, 7);
 };
 
 #endif  // REST_TRESTRAWPEAKSFINDERPROCESS_H

--- a/inc/TRestRawPeaksFinderProcess.h
+++ b/inc/TRestRawPeaksFinderProcess.h
@@ -31,7 +31,7 @@ class TRestRawPeaksFinderProcess : public TRestEventProcess {
     Bool_t fRemovePeaklessVetoes = false;
 
     std::string fSimulationTriggerType = "tpc";
-    Double_t fSimulationTriggerHeight = 450.0; // ADC units, approx 2F threshold
+    Double_t fSimulationTriggerHeight = 450.0;  // ADC units, approx 2F threshold
 
     Double_t fTimeBinToTimeFactorMultiplier = 0.0;
     Double_t fTimeBinToTimeFactorOffset = 0.0;

--- a/inc/TRestRawPeaksFinderProcess.h
+++ b/inc/TRestRawPeaksFinderProcess.h
@@ -30,7 +30,9 @@ class TRestRawPeaksFinderProcess : public TRestEventProcess {
     /// \brief option to remove peak-less veto signals after finding the peaks
     Bool_t fRemovePeaklessVetoes = false;
 
-    UShort_t fSimulationZeroTimeBin = 210;
+    std::string fSimulationTriggerType = "tpc";
+    Double_t fSimulationTriggerHeight = 450.0; // ADC units, approx 2F threshold
+
     Double_t fTimeBinToTimeFactorMultiplier = 0.0;
     Double_t fTimeBinToTimeFactorOffset = 0.0;
     Double_t fTimeBinToTimeFactorOffsetTCM = 0.0;

--- a/src/TRestRawPeaksFinderProcess.cxx
+++ b/src/TRestRawPeaksFinderProcess.cxx
@@ -384,7 +384,8 @@ void TRestRawPeaksFinderProcess::InitFromConfigFile() {
     fRemoveAllVetoes = StringToBool(GetParameter("removeAllVetoes", fRemoveAllVetoes));
     fRemovePeaklessVetoes = StringToBool(GetParameter("removePeaklessVetoes", fRemovePeaklessVetoes));
 
-    fSimulationZeroTimeBin = UShort_t(GetDblParameterWithUnits("simulationZeroTimeBin", fSimulationZeroTimeBin));
+    fSimulationZeroTimeBin =
+        UShort_t(GetDblParameterWithUnits("simulationZeroTimeBin", fSimulationZeroTimeBin));
 
     fTimeConversionElectronics =
         StringToBool(GetParameter("trigDelayElectronics", fTimeConversionElectronics));

--- a/src/TRestRawPeaksFinderProcess.cxx
+++ b/src/TRestRawPeaksFinderProcess.cxx
@@ -258,7 +258,8 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
                     }
                 }
 
-                // If this signal has a valid first bin where the threshold is exceeded, compare it to the smallestBin
+                // If this signal has a valid first bin where the threshold is exceeded, compare it to the
+                // smallestBin
                 if (firstBinForSignal != UShort_t(-1)) {
                     if (smallestBin == UShort_t(-1) || firstBinForSignal < smallestBin) {
                         smallestBin = firstBinForSignal;
@@ -268,28 +269,31 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
 
             if (smallestBin == UShort_t(-1)) {
                 std::cout << "No valid bin found across all signals." << std::endl;
-            } else {// Determine if the current processing type matches the trigger type. If not a correction is applied to find the equivalent trigger bin in different signals types
+            } else {  // Determine if the current processing type matches the trigger type. If not a
+                      // correction is applied to find the equivalent trigger bin in different signals types
                 bool isTriggerTypeTPC = (fSimulationTriggerType == "tpc");
                 bool isProcessingTPC = (fChannelTypes.find("tpc") != fChannelTypes.end());
-                
+
                 if ((isTriggerTypeTPC && isProcessingTPC) || (!isTriggerTypeTPC && !isProcessingTPC)) {
-                    triggerBin = smallestBin;  // No correction needed if trigger type and processing type are the same
+                    triggerBin =
+                        smallestBin;  // No correction needed if trigger type and processing type are the same
                 } else {
                     triggerBin = smallestBin - 10;  // Apply correction
                 }
-    
+
                 // Lambda to convert time bin to time using the found smallest bin (triggerBin)
                 timeBinToTime = [this, &triggerBin](UShort_t timeBin) {
-                    return fTimeBinToTimeFactorMultiplier * (timeBin - triggerBin);  // Convert the time bin to time
+                    return fTimeBinToTimeFactorMultiplier *
+                           (timeBin - triggerBin);  // Convert the time bin to time
                 };
             }
 
-        } else {    // EXPERIMENTAL (trigger bin is found via electronics)
+        } else {  // EXPERIMENTAL (trigger bin is found via electronics)
             // @jporron
             timeBinToTime = [this, &triggerBin](UShort_t timeBin) {
                 triggerBin = -1 + (512 * fTimeBinToTimeFactorMultiplier - fTimeBinToTimeFactorOffset -
-                                    fTimeBinToTimeFactorOffsetTCM) /
-                                fTimeBinToTimeFactorMultiplier;
+                                   fTimeBinToTimeFactorOffsetTCM) /
+                                      fTimeBinToTimeFactorMultiplier;
                 return fTimeBinToTimeFactorMultiplier * (timeBin - triggerBin);
             };
         }
@@ -439,11 +443,11 @@ void TRestRawPeaksFinderProcess::InitFromConfigFile() {
     fTimeConversionElectronics =
         StringToBool(GetParameter("trigDelayElectronics", fTimeConversionElectronics));
     fSimulationTriggerType = GetParameter("simulationTriggerType", fSimulationTriggerType);
-        if (fSimulationTriggerType != "tpc" && fSimulationTriggerType != "veto") {
-            std::cerr << "Warning: Invalid simulationTriggerType '" << fSimulationTriggerType 
-                      << "'. Defaulting to 'tpc'." << std::endl;
-            fSimulationTriggerType = "tpc";
-        }
+    if (fSimulationTriggerType != "tpc" && fSimulationTriggerType != "veto") {
+        std::cerr << "Warning: Invalid simulationTriggerType '" << fSimulationTriggerType
+                  << "'. Defaulting to 'tpc'." << std::endl;
+        fSimulationTriggerType = "tpc";
+    }
     fSimulationTriggerHeight = GetDblParameterWithUnits("simulationTriggerHeight", fSimulationTriggerHeight);
 
     fTimeBinToTimeFactorMultiplier = GetDblParameterWithUnits("sampling", fTimeBinToTimeFactorMultiplier);
@@ -520,8 +524,10 @@ void TRestRawPeaksFinderProcess::PrintMetadata() {
     RESTMetadata << "Remove peakless vetoes: " << fRemovePeaklessVetoes << RESTendl;
 
     RESTMetadata << "Data taken with electronics: " << fTimeConversionElectronics << RESTendl;
-    RESTMetadata << "Simulation trigger type (only used if simulation): " << fSimulationTriggerType << RESTendl;
-    RESTMetadata << "Simulation trigger height in ADC units (only used if simulation): " << fSimulationTriggerHeight << RESTendl;
+    RESTMetadata << "Simulation trigger type (only used if simulation): " << fSimulationTriggerType
+                 << RESTendl;
+    RESTMetadata << "Simulation trigger height in ADC units (only used if simulation): "
+                 << fSimulationTriggerHeight << RESTendl;
 
     RESTMetadata << "Sampling: " << fTimeBinToTimeFactorMultiplier << RESTendl;
     RESTMetadata << "Trigger delay: " << fTimeBinToTimeFactorOffset << RESTendl;

--- a/src/TRestRawPeaksFinderProcess.cxx
+++ b/src/TRestRawPeaksFinderProcess.cxx
@@ -224,24 +224,75 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
     SetObservableValue("windowTimeBin", windowCenter);
     SetObservableValue("windowMultiplicity", windowMultiplicity);
 
+    int triggerBin = -1;
+
     if (fTimeBinToTimeFactorMultiplier != 0.0) {
         vector<Double_t> windowCenterTime(windowCenter.size(), 0.0);
         vector<Double_t> windowPeakCenterTime(windowPeakCenter.size(), 0.0);
         vector<Double_t> peaksTimePhysical(peaksTime.size(), 0.0);
 
-        // lambda to convert time bin to time
-        auto timeBinToTime = [this](UShort_t timeBin) {
-            if (!fTimeConversionElectronics) {
-                UShort_t simulation_zero_bin = fSimulationZeroTimeBin;
-                return fTimeBinToTimeFactorMultiplier * (timeBin - simulation_zero_bin);
-            } else {
-                // @jporron
-                double zero = -1 + (512 * fTimeBinToTimeFactorMultiplier - fTimeBinToTimeFactorOffset -
-                                    fTimeBinToTimeFactorOffsetTCM) /
-                                       fTimeBinToTimeFactorMultiplier;
-                return fTimeBinToTimeFactorMultiplier * (timeBin - zero);
+        std::function<Double_t(UShort_t)> timeBinToTime;
+
+        if (!fTimeConversionElectronics) {  // SIMULATION (trigger bin is defined as input)
+            UShort_t smallestBin = UShort_t(-1);
+
+            // Loop through all signals to find the first bin where the threshold is exceeded
+            for (int signalIndex = 0; signalIndex < fInputEvent->GetNumberOfSignals(); signalIndex++) {
+                const auto signal = fInputEvent->GetSignal(signalIndex);
+                const UShort_t signalId = signal->GetSignalID();
+                const string channelType = fReadoutMetadata->GetTypeForChannelDaqId(signalId);
+
+                // Skip if this signal is not of the selected trigger type (tpc or veto)
+                if (channelType != fSimulationTriggerType) {
+                    continue;
+                }
+
+                // Find the first bin where the threshold is exceeded for this signal
+                UShort_t firstBinForSignal = UShort_t(-1);
+                for (UShort_t bin = 0; bin < signal->GetNumberOfPoints(); bin++) {
+                    double binValue = signal->GetData(bin);
+
+                    if (binValue >= fSimulationTriggerHeight) {
+                        firstBinForSignal = bin;
+                        break;
+                    }
+                }
+
+                // If this signal has a valid first bin where the threshold is exceeded, compare it to the smallestBin
+                if (firstBinForSignal != UShort_t(-1)) {
+                    if (smallestBin == UShort_t(-1) || firstBinForSignal < smallestBin) {
+                        smallestBin = firstBinForSignal;
+                    }
+                }
             }
-        };
+
+            if (smallestBin == UShort_t(-1)) {
+                std::cout << "No valid bin found across all signals." << std::endl;
+            } else {// Determine if the current processing type matches the trigger type. If not a correction is applied to find the equivalent trigger bin in different signals types
+                bool isTriggerTypeTPC = (fSimulationTriggerType == "tpc");
+                bool isProcessingTPC = (fChannelTypes.find("tpc") != fChannelTypes.end());
+                
+                if ((isTriggerTypeTPC && isProcessingTPC) || (!isTriggerTypeTPC && !isProcessingTPC)) {
+                    triggerBin = smallestBin;  // No correction needed if trigger type and processing type are the same
+                } else {
+                    triggerBin = smallestBin - 10;  // Apply correction
+                }
+    
+                // Lambda to convert time bin to time using the found smallest bin (triggerBin)
+                timeBinToTime = [this, &triggerBin](UShort_t timeBin) {
+                    return fTimeBinToTimeFactorMultiplier * (timeBin - triggerBin);  // Convert the time bin to time
+                };
+            }
+
+        } else {    // EXPERIMENTAL (trigger bin is found via electronics)
+            // @jporron
+            timeBinToTime = [this, &triggerBin](UShort_t timeBin) {
+                triggerBin = -1 + (512 * fTimeBinToTimeFactorMultiplier - fTimeBinToTimeFactorOffset -
+                                    fTimeBinToTimeFactorOffsetTCM) /
+                                fTimeBinToTimeFactorMultiplier;
+                return fTimeBinToTimeFactorMultiplier * (timeBin - triggerBin);
+            };
+        }
 
         for (size_t i = 0; i < windowCenter.size(); i++) {
             windowCenterTime[i] = timeBinToTime(windowCenter[i]);
@@ -258,6 +309,7 @@ TRestEvent* TRestRawPeaksFinderProcess::ProcessEvent(TRestEvent* inputEvent) {
         SetObservableValue("windowTime", windowCenterTime);
         SetObservableValue("windowPeakTime", windowPeakCenterTime);
         SetObservableValue("peaksTime", peaksTimePhysical);
+        SetObservableValue("triggerBin", triggerBin);
     }
 
     if (fADCtoEnergyFactor != 0.0 || !fChannelIDToADCtoEnergyFactor.empty()) {
@@ -384,11 +436,16 @@ void TRestRawPeaksFinderProcess::InitFromConfigFile() {
     fRemoveAllVetoes = StringToBool(GetParameter("removeAllVetoes", fRemoveAllVetoes));
     fRemovePeaklessVetoes = StringToBool(GetParameter("removePeaklessVetoes", fRemovePeaklessVetoes));
 
-    fSimulationZeroTimeBin =
-        UShort_t(GetDblParameterWithUnits("simulationZeroTimeBin", fSimulationZeroTimeBin));
-
     fTimeConversionElectronics =
         StringToBool(GetParameter("trigDelayElectronics", fTimeConversionElectronics));
+    fSimulationTriggerType = GetParameter("simulationTriggerType", fSimulationTriggerType);
+        if (fSimulationTriggerType != "tpc" && fSimulationTriggerType != "veto") {
+            std::cerr << "Warning: Invalid simulationTriggerType '" << fSimulationTriggerType 
+                      << "'. Defaulting to 'tpc'." << std::endl;
+            fSimulationTriggerType = "tpc";
+        }
+    fSimulationTriggerHeight = GetDblParameterWithUnits("simulationTriggerHeight", fSimulationTriggerHeight);
+
     fTimeBinToTimeFactorMultiplier = GetDblParameterWithUnits("sampling", fTimeBinToTimeFactorMultiplier);
     fTimeBinToTimeFactorOffset = GetDblParameterWithUnits("trigDelay", fTimeBinToTimeFactorOffset);
     fTimeBinToTimeFactorOffsetTCM = GetDblParameterWithUnits("trigDelayTCM", fTimeBinToTimeFactorOffsetTCM);
@@ -462,9 +519,9 @@ void TRestRawPeaksFinderProcess::PrintMetadata() {
     RESTMetadata << "Remove all vetoes: " << fRemoveAllVetoes << RESTendl;
     RESTMetadata << "Remove peakless vetoes: " << fRemovePeaklessVetoes << RESTendl;
 
-    RESTMetadata << "Simulation zero time bin: " << fSimulationZeroTimeBin << RESTendl;
-
     RESTMetadata << "Data taken with electronics: " << fTimeConversionElectronics << RESTendl;
+    RESTMetadata << "Simulation trigger type (only used if simulation): " << fSimulationTriggerType << RESTendl;
+    RESTMetadata << "Simulation trigger height in ADC units (only used if simulation): " << fSimulationTriggerHeight << RESTendl;
 
     RESTMetadata << "Sampling: " << fTimeBinToTimeFactorMultiplier << RESTendl;
     RESTMetadata << "Trigger delay: " << fTimeBinToTimeFactorOffset << RESTendl;


### PR DESCRIPTION
![JPorron](https://badgen.net/badge/PR%20submitted%20by%3A/JPorron/blue) ![Ok: 31](https://badgen.net/badge/PR%20Size/Ok%3A%2031/green) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/jporron-PeaksFinder-simulation-realTime/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/jporron-PeaksFinder-simulation-realTime) [![](https://github.com/rest-for-physics/rawlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=jporron-PeaksFinder-simulation-realTime)](https://github.com/rest-for-physics/rawlib/commits/jporron-PeaksFinder-simulation-realTime) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

It is useful to convert the bin time of the detected peaks to physical time. This way we can directly compare when the peaks happen for tpc signals and veto signals, overcoming the issues that arise when we take into account the different sampling, trigger delay, ... of the different types of signal. 

The fact that a tpc peak happens in bin 256 and a veto peak happens at bin 150, for example, is not directly comparable since for each signal type the bin time is one or another for the same bin (given the sampling for each type) and the signals will be placed at particular bins (given the trigger delay for each type).

When the physical times are comparable we can find interesting information, for example, tpc peaks will always be after the trigger and the physical time distance between the maximum and minimum is related to the drift velocity (an energy deposition near the cathode will produce a peak further in time than an energy deposition near the mesh, whose peak will be almost instantaneous after the trigger and this time difference is related to the time the electrons produced near the cathode take to reach the mesh and produce the peak).

![image](https://github.com/user-attachments/assets/73be0cd0-39c0-4b14-a18c-1c8298f08077)

_**A new observable is added to compute the zero time bin**_ (the bin at which the trigger happens) in simulations and the bin time difference between the peak position and this zero bin gives the physical time from the trigger to the maximum energy deposition (when most electrons reach the mesh).