### PR TITLE
New process TRestRawZeroSupressionToRawProcess

### DIFF
--- a/inc/TRestRawSignal.h
+++ b/inc/TRestRawSignal.h
@@ -159,6 +159,8 @@ class TRestRawSignal {
 
     void InitializePointsOverThreshold(const TVector2& thrPar, Int_t nPointsOver, Int_t nPointsFlat = 512);
 
+    void ZeroSuppressionToRaw();
+
     UInt_t GetSeed() const { return fSeed; }
 
     Double_t GetIntegral();

--- a/inc/TRestRawZeroSupressionToRawProcess.h
+++ b/inc/TRestRawZeroSupressionToRawProcess.h
@@ -1,0 +1,62 @@
+/*************************************************************************
+ * This file is part of the REST software framework.                     *
+ *                                                                       *
+ * Copyright (C) 2016 GIFNA/TREX (University of Zaragoza)                *
+ * For more information see http://gifna.unizar.es/trex                  *
+ *                                                                       *
+ * REST is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * REST is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          *
+ * GNU General Public License for more details.                          *
+ *                                                                       *
+ * You should have a copy of the GNU General Public License along with   *
+ * REST in $REST_PATH/LICENSE.                                           *
+ * If not, see http://www.gnu.org/licenses/.                             *
+ * For the list of contributors see $REST_PATH/CREDITS.                  *
+ *************************************************************************/
+
+#ifndef RESTProc_TRestRawZeroSupressionToRawProcess
+#define RESTProc_TRestRawZeroSupressionToRawProcess
+
+#include "TRestEvent.h"
+#include "TRestEventProcess.h"
+#include "TRestRawSignalEvent.h"
+
+/// This process remove the offset on a zerosuppression acquired event
+class TRestRawZeroSupressionToRawProcess : public TRestEventProcess {
+   private:
+    /// Pointer to TRestRawSignalEvent input event
+    TRestRawSignalEvent* fEvent;  //!
+
+    void Initialize() override;
+
+   public:
+    RESTValue GetInputEvent() const override { return fEvent; }
+    RESTValue GetOutputEvent() const override { return fEvent; }
+
+    void InitProcess() override;
+
+    const char* GetProcessName() const override { return "ZeroSupressionToRaw"; }
+
+    TRestEvent* ProcessEvent(TRestEvent* eventInput) override;
+
+    void EndProcess() override;
+
+    /// It prints out the process parameters stored in the metadata structure
+    void PrintMetadata() override {
+        BeginPrintProcess();
+
+        EndPrintProcess();
+    }
+
+    TRestRawZeroSupressionToRawProcess();
+    ~TRestRawZeroSupressionToRawProcess();
+
+    ClassDefOverride(TRestRawZeroSupressionToRawProcess, 1);
+};
+#endif

--- a/src/TRestRawSignal.cxx
+++ b/src/TRestRawSignal.cxx
@@ -983,6 +983,20 @@ void TRestRawSignal::WriteSignalToTextFile(const TString& filename) {
 }
 
 ///////////////////////////////////////////////
+/// \brief This method transforms zero suppression
+/// raw data into a raw data event using the firs
+///
+void TRestRawSignal::ZeroSuppressionToRaw() {
+    Short_t offset = 0;
+    for (int i = 0; i < GetNumberOfPoints(); i++) {
+        const Short_t val = fSignalData[i];
+        if (val == 0) continue;
+        if (offset == 0) offset = val;
+        fSignalData[i] = val - offset;
+    }
+}
+
+///////////////////////////////////////////////
 /// \brief It prints the signal data on screen.
 ///
 void TRestRawSignal::Print() const {

--- a/src/TRestRawZeroSupressionToRawProcess.cxx
+++ b/src/TRestRawZeroSupressionToRawProcess.cxx
@@ -1,0 +1,92 @@
+/*************************************************************************
+ * This file is part of the REST software framework.                     *
+ *                                                                       *
+ * Copyright (C) 2016 GIFNA/TREX (University of Zaragoza)                *
+ * For more information see http://gifna.unizar.es/trex                  *
+ *                                                                       *
+ * REST is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * REST is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          *
+ * GNU General Public License for more details.                          *
+ *                                                                       *
+ * You should have a copy of the GNU General Public License along with   *
+ * REST in $REST_PATH/LICENSE.                                           *
+ * If not, see http://www.gnu.org/licenses/.                             *
+ * For the list of contributors see $REST_PATH/CREDITS.                  *
+ *************************************************************************/
+
+/////////////////////////////////////////////////////////////////////////
+/// TRestRawZeroSuppressionToRaw process remove the offset on a zerosuppression
+/// acquired event using the first bin as baseline.
+///
+/// ### Examples
+/// Give examples of usage and RML descriptions that can be tested.
+/// \code
+///     <addProcess type="TRestRawZeroSupressionToRawProcess" name="zS2Raw" value="ON" />
+/// \endcode
+///
+/// REST-for-Physics - Software for Rare Event Searches Toolkit
+///
+/// History of developments:
+///
+/// 2023-June: First implementation of TRestRawZeroSupressionToRawProcess
+/// JuanAn Garcia
+///
+/// \class TRestRawZeroSupressionToRawProcess
+/// \author: JuanAn Garcia juanangp@unizar.es
+///
+/// <hr>
+///
+
+#include "TRestRawZeroSupressionToRawProcess.h"
+
+ClassImp(TRestRawZeroSupressionToRawProcess);
+
+///////////////////////////////////////////////
+/// \brief Default constructor
+///
+TRestRawZeroSupressionToRawProcess::TRestRawZeroSupressionToRawProcess() { Initialize(); }
+
+///////////////////////////////////////////////
+/// \brief Default destructor
+///
+TRestRawZeroSupressionToRawProcess::~TRestRawZeroSupressionToRawProcess() {}
+
+///////////////////////////////////////////////
+/// \brief Function to initialize input/output event members and define
+/// the section name
+///
+void TRestRawZeroSupressionToRawProcess::Initialize() {
+    SetSectionName(this->ClassName());
+    SetLibraryVersion(LIBRARY_VERSION);
+    fEvent = nullptr;
+}
+
+///////////////////////////////////////////////
+/// \brief Process initialization.
+///
+void TRestRawZeroSupressionToRawProcess::InitProcess() {}
+
+///////////////////////////////////////////////
+/// \brief The main processing event function
+///
+TRestEvent* TRestRawZeroSupressionToRawProcess::ProcessEvent(TRestEvent* evInput) {
+    fEvent = (TRestRawSignalEvent*)evInput;
+    for (int n = 0; n < fEvent->GetNumberOfSignals(); n++) {
+        TRestRawSignal* rawSignal = fEvent->GetSignal(n);
+        rawSignal->ZeroSuppressionToRaw();
+    }
+
+    return fEvent;
+}
+
+///////////////////////////////////////////////
+/// \brief Function to include required actions after all events have been
+/// processed.
+///
+void TRestRawZeroSupressionToRawProcess::EndProcess() {}


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Medium: 170](https://badgen.net/badge/PR%20Size/Medium%3A%20170/orange) [![](https://gitlab.cern.ch/rest-for-physics/rawlib/badges/rawZero2Raw/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/rawlib/-/commits/rawZero2Raw) [![](https://github.com/rest-for-physics/rawlib/actions/workflows/frameworkValidation.yml/badge.svg?branch=rawZero2Raw)](https://github.com/rest-for-physics/rawlib/commits/rawZero2Raw) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

TRestRawZeroSupressionToRawProcess is meant to remove the baseline of the raw data adquired in zero suppression using the first point of the pulses as baseline.